### PR TITLE
Copyediting: Syntax, semantics, pragmatics

### DIFF
--- a/msix-src/msix-1709-and-1803-support.md
+++ b/msix-src/msix-1709-and-1803-support.md
@@ -1,6 +1,6 @@
 ---
 author: c-don
-title: MSIX support on builds 1709 and 1803
+title: MSIX support on 1709 and 1803
 description: This article summarizes the support for MSIX with our latest updates as of 1/22/2019.
 ms.author: cdon
 ms.date: 04/04/2019
@@ -11,18 +11,16 @@ ms.custom: "RS5, seodec18"
 ---
 
 
-# MSIX support on Windows 10 builds 1709 and 1803
+# MSIX support on Windows 10, 1709 and 1803
 
 This article summarizes the MSIX support and limitations with our latest updates.
 
 By popular demand, we have added support for MSIX on more Windows 10 versions. Most notably, this covers versions 1709 and 1803. This support allows users to deploy MSIX packages on earlier Windows versions, while taking advantage of all benefits of MSIX, including containerization and security through certificates. To take advantage of these updates, make sure you have the 1.0.30311 or later version of App Installer and the latest servicing fixes on your 1709 and 1803 devices.
 
-Below, we discuss features and limitations of MSIX support on the earlier OS versions.
-
 ##  MSIX double-click support
-One of the benefits of deploying an MSIX on version 1809 and later is that the user can install the package by clicking on it. With the latest version of the App Installer - 1.0.30311.0 - the ability to install an MSIX package by clicking on it is available on 1709 and 1803 as well. 
+One of the benefits of deploying an MSIX package on version 1809 and later is that the user can install the package by clicking on it. With the latest version of App Installer (1.0.30311.0), the ability to install an MSIX package by clicking on it is available on 1709 and 1803 as well. 
 
-Clicking on the package provides the same installation support as in 1809, namely Microsoft's App Installer application shows UI to the user that guides them through the app installation. The App Installer is pre-installed and gets updates from the store, so we can always bring you the best installation experience. 
+Clicking on the package provides the same installation support as in 1809, namely App Installer guides the user through the app installation. App Installer is pre-installed and gets updated from Microsoft Store, so we can always bring you the best installation experience. 
 
 Below is a summary of the click-to-install MSIX support available on 1709 and 1803.
 
@@ -30,37 +28,37 @@ Below is a summary of the click-to-install MSIX support available on 1709 and 18
 
 | OS Version|.msix|.msixbundle|.appx|.appxbundle|
 |:-------------:|:--------:|:--------:|:--------:|:--------:|
-| Win 10 1709(16299) | &#x2713; | &#x2717; | &#x2713; | &#x2713; | 
-| Win 10 1803(17134) | &#x2713; | &#x2717; | &#x2713; | &#x2713; |
-| Win 10 1809(17763) and above | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| Windows 10, 1709<br/>(build 16299) | &#x2713; | &#x2717; | &#x2713; | &#x2713; | 
+| Windows 10, 1803<br/>(build 17134) | &#x2713; | &#x2717; | &#x2713; | &#x2713; |
+| Windows 10, 1809<br/>(build 17763) and later | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
 
 
 > [!NOTE] 
-> MSIXbundles are not supported on Windows 10 versions 1709 and 1803.  Developers looking to build packages compatible with these Windows versions can leverage the .appxbundle technology.
+> The `.MSIXbundle` format is not supported on Windows 10 versions 1709 and 1803. Developers looking to build packages compatible with these Windows versions can leverage the `.appxbundle` technology.
 
 ## MDM support
-Microsoft Intune and SCCM supports MSIX installation on 1709 and 1803. MSIX can be installed on these builds in the same way as it can in 1809 and later. 
+Microsoft Intune and System Center Configuration Manger (SCCM) supports MSIX installation on 1709 and 1803. MSIX packages can be installed on these versions in the same way as it can in 1809 and later. 
 
 ## Store support
-The minimum supported OS version of an MSIX is listed in the manifest file of the package as MinVersion in the TargetDeviceFamily element. For example an MSIX package may list MinVersion="10.0.17701.0" as the min supported version, which means that the MSIX can run on this and later versions of the OS.
+The minimum supported OS version of an MSIX package is listed in the manifest file of the package as `MinVersion` in the `TargetDeviceFamily` element. For example an MSIX package may list `MinVersion="10.0.17701.0"` as the min supported version, which means that the MSIX ackage can run on this and later versions of the OS.
 
-On 1709, 1803 and 1809 we support the mainstream enterprise deployment scenarios. These include installation through System Center Configuration Manger (SCCM), Microsoft Intune, scripting via PowerShell or double-click installation.
+On 1709, 1803 and 1809, we support the mainstream enterprise deployment scenarios. These include installation through SCCM, Microsoft Intune, PowerShell or double-click installation.
 
-Currently MSIX installation through the Microsoft Store and Microsoft Store for Business require Windows 10 version 1809.
+Currently, MSIX installation through Microsoft Store and Microsoft Store for Business require Windows 10 version 1809.
 
 ## Packaging & signing
-Currently to package and sign an MSIX, you need the 1809 SDK. Packaging and signing can be done via the SDK command line tools, the MSIX Packaging Tool or Visual Studio. 
+Currently, to package and sign an MSIX file, you need the 1809 SDK. Packaging and signing can be done via the SDK command line tools, MSIX Packaging Tool or Visual Studio. 
 
-## Auto elevation
+## Auto-elevation
 In rare instances, some apps require elevated privileges. 
 
-Users running MSIX on builds later than 1809 can use elevated privileges just by clicking on the app tile. The plaftorm detects that elevation is needed and automatically provides it when the user has the necessary credentials. 
+Users running an MSIX package on 1809 and later can use elevated privileges just by clicking on the app tile. The plaftorm detects that elevation is needed and automatically provides it when the user has the necessary credentials. 
 
-On builds 1709 and 1803, users can still run apps with elevated privileges, however they need to explicity select to run the app as an admin. One way to do that is by right-clicking on the app's tile and selecting the "Run as administrator" option.
+On 1709 and 1803, users can still run apps with elevated privileges; however, they need to explicity select to run the app as an administrator. One way to do that is by right-clicking on the app's tile and selecting the "Run as administrator" option.
 
-## Signature verification
-As mentioned earlier, we enforce proper signing of MSIX packages on all Windows versions 1709 and later. However, on the older Windows versions (1709 and 1803), IT Pros need to follow a few extra steps to verify the signature before releasing an app for their end users. Note, for the end user the MSIX experience does not change in any way. The end-user continues to install, launch and use the application as before, since the signature verification is handled by the IT Pros. 
+## Digital certificate verification
+As mentioned earlier, we enforce proper signing of MSIX packages on Windows 10 version 1709 and later. However, on the older Windows 10 versions (1709 and 1803), IT pros need to follow a few extra steps to verify the digital certificate before releasing an app for their end users. For the end user, the MSIX experience does not change in any way. The end-user continues to install, launch and use the app as before, since the certificate verification is handled by the IT pro.
 
-On Windows 10 versions 1809 and later, an IT Pro can verify the app's signature either from PowerShell or through the properties of the MSIX package. 
+On Windows 10 version 1809 and later, an IT pro can verify the digital certificate of an MSIX package either from PowerShell or the Properties dialog box of File Explorer.
 
-However, on versions 1709 and 1803 IT Pros cannot verify the signature from the MSIX package's properties, unless the 1809 SDK is installed. If the IT Pro has the 1809 SDK on a device with Windows 1709 through 1803, the signature can be verified through SDK tools from PowerShell. 
+However, on versions 1709 and 1803, IT pros cannot verify the certificate from File Explorer, unless the 1809 SDK is installed. If the IT Pro has the 1809 SDK on a device with Windows 1709 through 1803, the certificate can be verified through SDK tools from PowerShell.


### PR DESCRIPTION
1. Replaced incorrect uses of the word "build". 16299, 17134 and 17763 are Windows 10 build numbers, but 1709, 1803 and 1809 are not. (The latter three are version names.)
2. Removed incorrect uses of the definite article. Product names, like "Windows 10", "PowerShell", "Visual Studio", etc. must appear without it (unless these product names are followed a by descriptor clause, e.g. "the Windows 10 operating system".)
3. Fixed incorrect capitalization: It's "IT pro", not "IT Pro". The latter is the name of a publication.
4. Deleted a redundant sentence on line 19. An equivalent is already on line 16.
5. Replaced the mysterious "properties" word. I believe it refers to the "Properties..." dialog box of File Explorer and Windows Shell.