### PR TITLE
R2R compiler: Document the NgenR2R property.

### DIFF
--- a/msix-src/desktop/desktop-to-uwp-r2r.md
+++ b/msix-src/desktop/desktop-to-uwp-r2r.md
@@ -76,6 +76,8 @@ To verify that the tool has processed the binaries you can review the build outp
 Native image obj\x86\Release\\R2R\DesktopApp1.exe generated successfully.
 ```
 
+Native image compilation can be triggered on non-release builds by setting the property `NgenR2R` to `true` in the project file.
+
 ## FAQ
 
 **Q. Do the new binaries work on machines without .NET Framework 4.7.2?**


### PR DESCRIPTION
Document the ability to trigger native compilation on non-release
build configurations by setting the `NgenR2R` property.

Fixes #38.