### PR TITLE
Removed outdated references to UWP behaviour

### DIFF
--- a/msix-src/desktop/desktop-to-uwp-behind-the-scenes.md
+++ b/msix-src/desktop/desktop-to-uwp-behind-the-scenes.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 
 This article provides a deeper dive on what happens to files and registry entries when you create a Windows app package for your desktop application.
 
-A key goal of a modern package is to separate application state from system state as much as possible while maintaining compatibility with other apps. Windows 10 accomplishes this by placing the application inside a Universal Windows Platform (UWP) package, and then detecting and redirecting some changes  it makes to the file system and registry at runtime.
+A key goal of a modern package is to separate application state from system state as much as possible while maintaining compatibility with other apps. Windows 10 accomplishes this by placing the application inside a MSIX package, and then detecting and redirecting some changes it makes to the file system and registry at runtime.
 
 Packages that you create for your desktop application are desktop-only, full-trust applications and are not virtualized or sandboxed. This allows them to interact with other apps the same way classic desktop applications do.
 

--- a/msix-src/desktop/desktop-to-uwp-prepare.md
+++ b/msix-src/desktop/desktop-to-uwp-prepare.md
@@ -1,6 +1,6 @@
 ---
 Description: This article lists things you need to know before packaging your desktop application. You may not need to do much to get your app ready for the packaging process.
-title: Prepare to package a desktop application (Desktop Bridge)
+title: Prepare to package a desktop application (MSIX)
 ms.date: 08/22/2019
 ms.topic: article
 keywords: windows 10, uwp, msix
@@ -32,7 +32,7 @@ This article lists the things you need to know before you package your desktop a
 
 + __Your application uses a ddeexec registry subkey as a means of launching another app__. Instead, use one of the DelegateExecute verb handlers as configured by the various Activatable* extensions in your [app package manifest](https://msdn.microsoft.com/library/windows/apps/br211474.aspx).
 
-+ __Your application writes to the AppData folder or to the registry with the intention of sharing data with another app__. After conversion, AppData is redirected to the local app data store, which is a private store for each UWP app.
++ __Your application writes to the AppData folder or to the registry with the intention of sharing data with another app__. After conversion, AppData is redirected to the local app data store, which is a private store for each app.
 
   All entries that your application writes to the HKEY_LOCAL_MACHINE registry hive are redirected to an isolated binary file and any entries that your application writes to the HKEY_CURRENT_USER registry hive are placed into a private per-user, per-app location. For more details about file and registry redirection, see [Behind the scenes of the Desktop Bridge](desktop-to-uwp-behind-the-scenes.md).  
 
@@ -44,7 +44,7 @@ This article lists the things you need to know before you package your desktop a
 
 + __Your application uses the Current Working Directory__. At runtime, your packaged desktop application won't get the same Working Directory that you previously specified in your desktop .LNK shortcut. You need to change your CWD at runtime if having the correct directory is important for your application to function correctly.
 
-+ __Your application requires UIAccess__. If your application specifies `UIAccess=true` in the `requestedExecutionLevel` element of the UAC manifest, conversion to UWP isn't supported currently. For more info, see [UI Automation Security Overview](https://msdn.microsoft.com/library/ms742884.aspx).
++ __Your application requires UIAccess__. If your application specifies `UIAccess=true` in the `requestedExecutionLevel` element of the UAC manifest, conversion to MSIX isn't supported currently. For more info, see [UI Automation Security Overview](https://msdn.microsoft.com/library/ms742884.aspx).
 
 + __Your application exposes COM objects__. Processes and extensions from within the package can register and use COM & OLE servers, both in-process and out-of-process (OOP).  The Creators Update adds Packaged COM support which provides the ability to register OOP COM & OLE servers that are now visible outside the package.  See [COM Server and OLE Document support for Desktop Bridge](https://blogs.windows.com/windowsdeveloper/2017/04/13/com-server-ole-document-support-desktop-bridge).
 

--- a/msix-src/desktop/desktop-to-uwp-root.md
+++ b/msix-src/desktop/desktop-to-uwp-root.md
@@ -9,11 +9,11 @@ ms.localizationpriority: medium
 ms.custom: RS5
 ---
 
-# Package desktop applications (Desktop Bridge)
+# Package desktop applications (MSIX)
 
 Take your existing desktop application and add modern experiences for Windows 10 users. Then, achieve greater reach across international markets by distributing it through the Microsoft Store. You can monetize your application in much simpler ways by leveraging features built right into the Store. Of course, you don't have to use the Store. Feel free to use your existing channels.
 
-When you create a package for your desktop application, your application will get an identity and with that identity, your desktop application has access to Windows Universal Platform (UWP) APIs. You can use them to light up modern and engaging experiences such as live tiles and notifications. Use simple conditional compilation and runtime checks to run UWP code only when your application runs on Windows 10.
+When you create an MSIX package for your desktop application, your application will get an identity and with that identity, your desktop application has access to Windows Universal Platform (UWP) APIs. You can use them to light up modern and engaging experiences such as live tiles and notifications. Use simple conditional compilation and runtime checks to run UWP code only when your application runs on Windows 10.
 
 Aside from the code that you use to light up Windows 10 experiences, your application remains unchanged and you can continue to distribute it to users on previous versions of Windows. On Windows 10, your application continues to run in full-trust user mode just like it’s doing today.
 


### PR DESCRIPTION
There were a few lingering references to things being UWP or desktop bridge only across a bunch of files. Updated them to say MSIX as well where required

