### PR TITLE
Fix $pwd usage in code example

### DIFF
--- a/msix-src/package/create-certificate-package-signing.md
+++ b/msix-src/package/create-certificate-package-signing.md
@@ -81,8 +81,8 @@ When using **Export-PfxCertificate**, you must either create and use a password 
 ### Password usage
 
 ```powershell
-$pwd = ConvertTo-SecureString -String <Your Password> -Force -AsPlainText 
-Export-PfxCertificate -cert "Cert:\CurrentUser\My\<Certificate Thumbprint>" -FilePath <FilePath>.pfx -Password $pwd
+$password = ConvertTo-SecureString -String <Your Password> -Force -AsPlainText 
+Export-PfxCertificate -cert "Cert:\CurrentUser\My\<Certificate Thumbprint>" -FilePath <FilePath>.pfx -Password $password
 ```
 
 ### ProtectTo usage


### PR DESCRIPTION
`$pwd` in PowerShell is a pre-defined variable with a the current path in it. The original code is working, but could be potentially confusing and will break if user changes directory between first and second line.