### PR TITLE
Updating the self-signed certificate note/warning

### DIFF
--- a/msix-src/package/create-certificate-package-signing.md
+++ b/msix-src/package/create-certificate-package-signing.md
@@ -25,7 +25,7 @@ You need PKI cmdlets to create and export your signing certificate. For more inf
 A self-signed certificate is useful for testing your app before you're ready to publish it to the Store. Follow the steps outlined in this section to create a self-signed certificate.
 
 > [!NOTE]
-> Self-signed certificates are strictly for testing. When you are ready to publish your app either to the store or from other venues, switch the certificate to reputable source. Failure to do this may result in the inability for your app to get installed by your customers.
+> When you create and use a self-signed certificate only users who install and trust your certificate can run your application. This is easy to implement for testing but it may prevent additional users from installing your application. When you are ready to publish your application we recommend that you use a certificate issued by a trusted source. This system of centralized trust helps to ensure that the application ecosystem has levels of verification to protect users from malicious actors.
 
 ### Determine the subject of your packaged app  
 


### PR DESCRIPTION
Updating this note to be a bit more descriptive. We want to let users know exactly what problems they can expect with a self signed cert, and what the right remediation is.