### PR TITLE
Adding search scope

### DIFF
--- a/msix-src/docfx.json
+++ b/msix-src/docfx.json
@@ -42,7 +42,8 @@
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/msix-docs",
       "feedback_product_url": "https://aka.ms/msixcommunity",
-      "ms.prod": "msix"
+      "ms.prod": "msix",
+      "searchScope": ["MSIX"]
     },
     "fileMetadata": {
       "ms.author":


### PR DESCRIPTION
I've noticed you can't scope search results just to this docset