### PR TITLE
Update psf-current-working-directory.md

### DIFF
--- a/msix-src/psf/psf-current-working-directory.md
+++ b/msix-src/psf/psf-current-working-directory.md
@@ -67,7 +67,7 @@ An entry in processes has a value named executable, the value for which should b
     ],
     "processes": [
         {
-            "executable": "PSFSample",
+            "executable": "PSFSample"
         }
     ]
 }


### PR DESCRIPTION
On line 70 was a comma to close the line. But there are no lines after the Executable being defined. So it was crashing on this.