### PR TITLE
Link points to wrong page

### DIFF
--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -38,7 +38,7 @@ Developers have different tools to distribute their applications.  In the [Distr
 MSIX is a robust and reliable modern app install experience. The MSIX experience delivers a 99.96% successful install rate.  But there are some caveats. MSIX is not supported by default on all versions of Windows, and the supported feature set may very depending on which version of Windows 10 you are deploying to.  In the [Plan for your deployment](managing-your-msix-deployment-targetdevices.md) section we will discuss the importance of understanding the target device that the MSIX will be deployed to. 
 
 ## Providing support for my customer
-Though MSIX has a 99.96% successful install rate, you still need to plan how to support your customer.  In the [MSIX Validation and Troubleshooting section](managing-your-msix-deployment-overview.md) we discuss tools available for you to diagnose installation issues.
+Though MSIX has a 99.96% successful install rate, you still need to plan how to support your customer.  In the [MSIX Validation and Troubleshooting section](managing-your-msix-deployment-troubleshooting.md) we discuss tools available for you to diagnose installation issues.
 
 
  


### PR DESCRIPTION
The link is pointing to the current page rather than the troubleshooting page