### PR TITLE
Fixes a sample that contains a YAML document that is not valid

### DIFF
--- a/msix-src/desktop/azure-dev-ops.md
+++ b/msix-src/desktop/azure-dev-ops.md
@@ -44,7 +44,7 @@ variables:
   revision: $[counter('rev', 0)]
   
 steps:
- - powershell: |
+- powershell: |
      # Update appxmanifest. This must be done before the build.
      [xml]$manifest= get-content ".\Msix\Package.appxmanifest"
      $manifest.Package.Identity.Version = "$(major).$(minor).$(build).$(revision)"    


### PR DESCRIPTION
The first sample is not valid YAML. It's due to an extra leading space on line 13, instead of " - powershell: |", it should be "- powershell: |"

fixes #227
