### PR TITLE
App Installer Authentication Manager: Fix typo and spelling of Dropbox

### DIFF
--- a/msix-src/app-installer/app-installer-authentication-manager--overview.md
+++ b/msix-src/app-installer/app-installer-authentication-manager--overview.md
@@ -9,13 +9,13 @@ ms.localizationpriority: medium
 
 # App Installer Authentication Manager
 
-The Microsoft Desktop App Installer supports OAuth 2.0 authentication requests for identities hosted in Microsoft Azure Active Directory (AAD), Google, and Drop Box to access the Windows app installation media. The user will only be prompted for authentication if the Windows app installation media is inaccessible, by first attempting to access the media for display to the user. 
+The Microsoft Desktop App Installer supports OAuth 2.0 authentication requests for identities hosted in Microsoft Azure Active Directory (AAD), Google, and Dropbox to access the Windows app installation media. The user will only be prompted for authentication if the Windows app installation media is inaccessible, by first attempting to access the media for display to the user. 
 
-If authentication is required, the URI targetting the installation media must provide the identity hosting solution by including the suffix of `?msixauth=<identity provider>` to the URI. By specifying the identity provider, the Microsoft Desktop App Installer will connect to the desired identity provider to request authentication.
+If authentication is required, the URI targeting the installation media must provide the identity hosting solution by including the suffix of `?msixauth=<identity provider>` to the URI. By specifying the identity provider, the Microsoft Desktop App Installer will connect to the desired identity provider to request authentication.
 
 | Identity Service  | Identity Connection String  |
 |-------------------|-----------------------------|
 | Microsoft AAD     | msixauth=aad                |
 | Google            | msixauth=google             |
-| DropBox           | msixauth=dropbox            |
+| Dropbox           | msixauth=dropbox            |
 


### PR DESCRIPTION
Small edit to fix typo and correct spelling of Dropbox on the App Installer Authentication Manager page.