### PR TITLE
Update msix-container.md

### DIFF
--- a/msix-src/msix-container.md
+++ b/msix-src/msix-container.md
@@ -10,6 +10,6 @@ ms.custom: RS5
 
 # MSIX Container
 
-Apps that are packaged using MSIX run in a lightweight app container. The MSIX app process and its child processes run inside the container and are isolated using file system and registry virtualization. All MSIX apps can read the global registry. An MSIX app writes to its own virtual registry and application data folder, and this data will be deleted when the app is uninstalled or reset. Other apps do not have access to the virtual registry or virtual file system of an MSIX app.
+Apps that are packaged using MSIX run in a lightweight container. The MSIX app process and its child processes run inside the container and are isolated using file system and registry virtualization. All MSIX apps can read the global registry. An MSIX app writes to its own virtual registry and application data folder, and this data will be deleted when the app is uninstalled or reset. Other apps do not have access to the virtual registry or virtual file system of an MSIX app.
 
 For more information, visit [Understanding how MSIX packages run on Windows](desktop/desktop-to-uwp-behind-the-scenes.md). 


### PR DESCRIPTION
Super confusing that it says app container because it's very different from appcontainer.  Users are continually confused by this line.  SHould have a link to https://docs.microsoft.com/en-us/windows/win32/secauthz/appcontainer-isolation for what appcontainer does