### PR TITLE
Update create-shortcut-with-script-package-support-framework.md

### DIFF
--- a/msix-src/psf/create-shortcut-with-script-package-support-framework.md
+++ b/msix-src/psf/create-shortcut-with-script-package-support-framework.md
@@ -151,8 +151,8 @@ Switch back to the __MSIX Packaging Tool__, click on __Package files__, select t
   "applications": [
     {
       "id": "App",
-      "executable": "ContosoExpenses\\ContosoExpenses.exe",
-      "workingDirectory": "ContosoExpenses\\",
+      "executable": "ContosoExpenses/ContosoExpenses.exe",
+      "workingDirectory": "ContosoExpenses/",
       "startScript":
       {
         "scriptPath": "createshortcut.ps1",


### PR DESCRIPTION
Changing the directions of the back slashes to forward slashes in "Create the config.json file" as it contradicts other examples like https://docs.microsoft.com/en-us/windows/msix/psf/package-support-framework.