### PR TITLE
Update bundle-msix-packages.md

### DIFF
--- a/msix-src/packaging-tool/bundle-msix-packages.md
+++ b/msix-src/packaging-tool/bundle-msix-packages.md
@@ -24,7 +24,7 @@ You will need the following setup to successfully build an MSIX bundle:
 
 ## Step 1: Find MakeAppx.exe
 
-[MakeAppx.exe](/windows/desktop/appxpkg/make-appx-package--makeappx-exe-) is a tool available in the Windows 10 SDK that allows for packaging and bundling of MSIX packages. You will use this tool to bundle the two MSIX packages together.
+[MakeAppx.exe](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk) is a tool available in the Windows 10 SDK that allows for packaging and bundling of MSIX packages. You will use this tool to bundle the two MSIX packages together.
 
 MakeAppx.exe can be used to extract the file contents of a Windows 10 app package or bundle. It also encrypts and decrypts app packages and bundles.
 


### PR DESCRIPTION
Fixed broken link for MakeAppx.exe tool in the documentation. Updated link from https://github.com/MicrosoftDocs/msix-docs/blob/main/windows/desktop/appxpkg/make-appx-package--makeappx-exe- to https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk for correct download and usage instructions.