### PR TITLE
Fix mismatched step labels in App Installer file TOC

### DIFF
--- a/msix-src/app-installer/how-to-create-appinstaller-file.md
+++ b/msix-src/app-installer/how-to-create-appinstaller-file.md
@@ -27,9 +27,9 @@ To distribute your related set as one entity, you must create an App Installer f
 1. [Specify the main Windows app Package.](#step-3-add-the-main-package-information)
 1. [Specify the related set Optional Package.](#step-4-add-the-optional-packages)
 1. [Specify the dependency Windows app Framework Package.](#step-5-add-dependencies)
-1. [Specify the Update URI paths.](#step-6-add-update-setting)
-1. [Specify the Repair URI paths.](#step-7-add-auto-update-settings)
-1. [Specify the Update Settings.](#step-8-add-auto-repair-settings)
+1. [Specify the update settings.](#step-6-add-update-setting)
+1. [Specify the update URI paths.](#step-7-add-auto-update-settings)
+1. [Specify the repair URI paths.](#step-8-add-auto-repair-settings)
 
 
 ##### Example of an App Installer file


### PR DESCRIPTION
## Summary

Steps 6–8 in the [Create an App Installer file manually](https://learn.microsoft.com/windows/msix/app-installer/how-to-create-appinstaller-file) table of contents had their descriptions swapped/incorrect:

| Step | Old (incorrect) label | New (correct) label |
|------|-----------------------|---------------------|
| 6 | Specify the Update URI paths | Specify the update settings |
| 7 | Specify the Repair URI paths | Specify the update URI paths |
| 8 | Specify the Update Settings | Specify the repair URI paths |

The actual section headings and content were correct — only the TOC bullet text was wrong.

Fixes OS bug #40425473