### PR TITLE
MSIX hub: add What's new section; auto-update: remove stale Insider callout

### DIFF
--- a/msix-src/app-installer/auto-update-and-repair--overview.md
+++ b/msix-src/app-installer/auto-update-and-repair--overview.md
@@ -1,14 +1,20 @@
 ---
 title: Auto-update and repair apps
 description: Overview of the auto-update and repair settings for Windows apps installed using an AppInstaller file.
-ms.date: 4/15/2021
+ms.date: 04/10/2026
 ms.topic: article
-keywords: windows 10, uwp, app installer, AppInstaller
+keywords: windows 10, windows 11, uwp, app installer, AppInstaller, auto-update, auto-repair
 ---
 
 # Auto-update and repair apps
->[!Important]
-> The following article discusses settings currently available in Windows Insider build 22415 and newer.
+
+Auto-update and repair features are available on Windows 10, version 2004 (build 19041) and later, and on all versions of Windows 11.
+
+> [!NOTE]
+> Visual Studio generates `.appinstaller` files using the 2017/2 schema by default, which does not support `ShowPrompt` or `UpdateBlocksActivation`. To use those settings, manually set the schema version in your `.appinstaller` file to `2021`:
+> ```xml
+> <AppInstaller xmlns="http://schemas.microsoft.com/appx/appinstaller/2021" ...>
+> ```
 
 The auto-update and repair settings allows developers and IT pros to provide an automated update solution to Windows apps that are distributed without the use of the Microsoft Store. By specifying auto-updates and repair settings as part of your App Installer file, the Windows app can be configured to check for updates on every launch, hide the updating / repairing prompt, and/or prevent the Windows app from launching until it has received the latest update.
 

--- a/msix-src/index.yml
+++ b/msix-src/index.yml
@@ -42,8 +42,6 @@ additionalContent:
           summary: SDK 1.8 includes MSIX BuildTools refactoring and packaging improvements. See the stable channel release notes for details.
           url: /windows/apps/windows-app-sdk/stable-channel
 
-additionalContent:
-  sections:
     # Section
     - title: Top tasks
       items:

--- a/msix-src/index.yml
+++ b/msix-src/index.yml
@@ -5,7 +5,7 @@ metadata:
   title: MSIX documentation
   description: MSIX is a packaging format for Windows apps that is built to be safe and reliable. It is based on a combination of .msi, .appx, App-V and ClickOnce installation technologies. 
   ms.topic: hub-page
-  ms.date: 11/06/2019
+  ms.date: 04/10/2026
   keywords: windows 10, uwp, MSIX
   ms.localizationpriority: medium
   ms.custom: "RS5, seodec18"
@@ -25,6 +25,22 @@ highlightedContent:
    - title: MSIX Tech Community
      itemType: overview
      url: https://techcommunity.microsoft.com/t5/MSIX/ct-p/MSIX
+
+additionalContent:
+  sections:
+    # Section
+    - title: What's new for MSIX
+      summary: Recent improvements to the MSIX and Windows App SDK ecosystem.
+      items:
+        - title: Packaging decision guide
+          summary: Not sure which packaging model is right for your app? This new guide walks you through the decision — packaged, unpackaged, or packaging with external location.
+          url: /windows/apps/package-and-deploy/packaging/
+        - title: WinApp CLI
+          summary: The new WinApp command-line tool streamlines common MSIX packaging and signing workflows, including generating self-signed certificates and building packages from source.
+          url: /windows/apps/windows-app-sdk/winapp-cli
+        - title: Windows App SDK 1.8 — MSIX improvements
+          summary: SDK 1.8 includes MSIX BuildTools refactoring and packaging improvements. See the stable channel release notes for details.
+          url: /windows/apps/windows-app-sdk/stable-channel
 
 additionalContent:
   sections:


### PR DESCRIPTION
## Summary

Addresses two P0 items from the MSIX documentation improvement plan (ADO #569051).

### #1 — Update MSIX Hub to Cross-Link New Content

Adds a **"What's new for MSIX"** section to `index.yml` with cards linking to:
- [Packaging decision guide](/windows/apps/package-and-deploy/packaging/) (04/07/2026)
- [WinApp CLI](/windows/apps/windows-app-sdk/winapp-cli) (04/07/2026)
- [Windows App SDK 1.8 release notes](/windows/apps/windows-app-sdk/stable-channel)

Also updates the stale `ms.date` (was 11/06/2019).

### #2 — Remove Insider-Only Framing from Auto-Update Docs

In `auto-update-and-repair--overview.md`:
- **Removes** the Windows Insider build 22415 callout (feature has been GA since Windows 10 version 2004)
- **Adds** explicit availability statement: Windows 10 version 2004+ and all Windows 11
- **Adds** schema versioning callout: Visual Studio defaults to the 2017/2 `.appinstaller` schema, which lacks `ShowPrompt` and `UpdateBlocksActivation` support — developers need to manually upgrade to the 2021 schema
- Updates `ms.date` and keywords to include Windows 11