### PR TITLE
Make the PSF write-to-install-directory fixup how-to discoverable

### DIFF
--- a/msix-src/psf/package-support-framework-overview.md
+++ b/msix-src/psf/package-support-framework-overview.md
@@ -1,7 +1,7 @@
 ---
 description: The Package Support Framework helps you fix issues that prevent your desktop application from running in an MSIX container.
 title: Package Support Framework
-ms.date: 05/14/2020
+ms.date: 07/02/2026
 ms.topic: how-to
 keywords: windows 10, uwp, msix
 ms.custom: RS5
@@ -13,8 +13,8 @@ The Package Support Framework (PSF) is an open source kit that helps you apply f
 
 Here are some common examples where you can find the Package Support Framework useful:
 
-* Your app can't find some DLLs when launched. You may need to set your current working directory. You can learn about the required current working directory in the original shortcut before you converted to MSIX.
-* The app writes into the install folder. You will typically see it by "Access Denied" errors in [Process Monitor](./package-support-framework.md).
+* Your app can't find some DLLs when launched. You may need to set your current working directory. You can learn about the required current working directory in the original shortcut before you converted to MSIX. For a step-by-step fix, see [Windows app working directory error](psf-current-working-directory.md).
+* The app writes into the install folder. You will typically see it by "Access Denied" errors in [Process Monitor](./package-support-framework.md). For a step-by-step fix, see [How to fix Package Support Framework Filesystem Write Permission errors](psf-filesystem-writepermission.md).
 * Your app needs to pass parameters to the executable on launch. You can learn more how PSF can help by going [here](psf-launch-apps-with-parameters.md) and learn more about the available configurations [here](https://github.com/microsoft/MSIX-PackageSupportFramework/tree/master/PsfLauncher).
 
 This framework is open source, lightweight, and you can use it to address application issues quickly. It also gives you the opportunity to consult with the community around the globe, and to build on top of the investments of others.

--- a/msix-src/psf/package-support-framework-overview.md
+++ b/msix-src/psf/package-support-framework-overview.md
@@ -14,7 +14,7 @@ The Package Support Framework (PSF) is an open source kit that helps you apply f
 Here are some common examples where you can find the Package Support Framework useful:
 
 * Your app can't find some DLLs when launched. You may need to set your current working directory. You can learn about the required current working directory in the original shortcut before you converted to MSIX. For a step-by-step fix, see [Windows app working directory error](psf-current-working-directory.md).
-* The app writes into the install folder. You will typically see it by "Access Denied" errors in [Process Monitor](./package-support-framework.md). For a step-by-step fix, see [How to fix Package Support Framework Filesystem Write Permission errors](psf-filesystem-writepermission.md).
+* The app writes into the install folder. You will typically see it by "Access Denied" errors in [Process Monitor](/sysinternals/downloads/procmon). For a step-by-step fix, see [How to fix Package Support Framework Filesystem Write Permission errors](psf-filesystem-writepermission.md).
 * Your app needs to pass parameters to the executable on launch. You can learn more how PSF can help by going [here](psf-launch-apps-with-parameters.md) and learn more about the available configurations [here](https://github.com/microsoft/MSIX-PackageSupportFramework/tree/master/PsfLauncher).
 
 This framework is open source, lightweight, and you can use it to address application issues quickly. It also gives you the opportunity to consult with the community around the globe, and to build on top of the investments of others.

--- a/msix-src/psf/package-support-framework.md
+++ b/msix-src/psf/package-support-framework.md
@@ -1,7 +1,7 @@
 ---
 description: Learn about and how to use the components in the Package Support Framework to apply fixes to run in an MSIX container.
 title: Fix issues that prevent your desktop application from running in an MSIX container
-ms.date: 05/14/2020
+ms.date: 07/02/2026
 ms.topic: get-started
 keywords: windows 10, uwp
 ---
@@ -69,6 +69,9 @@ The PSF contains runtime fixes that you can use right now, such as the file redi
 You can use the [File Redirection Fixup](https://github.com/Microsoft/MSIX-PackageSupportFramework/tree/master/fixups/FileRedirectionFixup) to redirect attempts to write or read data in a directory that isn't accessible from an application that runs in an MSIX container.
 
 For example, if your application writes to a log file that is in the same directory as your applications executable, then you can use the [File Redirection Fixup](https://github.com/Microsoft/MSIX-PackageSupportFramework/tree/master/fixups/FileRedirectionFixup) to create that log file in another location, such as the local app data store.
+
+> [!TIP]
+> If you already know your app fails because it writes to its install directory, see the focused, end-to-end walkthrough in [How to fix Package Support Framework Filesystem Write Permission errors](psf-filesystem-writepermission.md).
 
 ### Runtime fixes from the community
 

--- a/msix-src/psf/psf-filesystem-writepermission.md
+++ b/msix-src/psf/psf-filesystem-writepermission.md
@@ -1,7 +1,7 @@
 ---
 title: Package Support Framework Filesystem Write Permission fix
 description: Learn how to identify and apply Filesystem Write Permission error fixes by using the MSIX Package Support Framework.
-ms.date: 05/10/2022
+ms.date: 07/02/2026
 ms.topic: how-to
 keywords: windows 10, uwp, psf, package support framework, filesystem, write permission, msix
 ms.custom: kr2b-contr-experiment
@@ -280,3 +280,11 @@ After you apply all the corrections, repackage the Windows app into an MSIX and 
     Set-Location "${env:ProgramFiles(x86)}\Windows Kits\10\Bin\$Win10SDKVersion\$OSArchitecture"
     .\signtool.exe sign /v /fd sha256 /f $CodeSigningCert /p $CodeSigningPass $AppPath
     ```
+
+## Related articles
+
+- [Package Support Framework overview](package-support-framework-overview.md)
+- [Get started with the Package Support Framework](package-support-framework.md)
+- [Windows app working directory error](psf-current-working-directory.md)
+- [Windows app launcher parameter requirement](psf-launch-apps-with-parameters.md)
+- [Run scripts with the Package Support Framework](run-scripts-with-package-support-framework.md)


### PR DESCRIPTION
Resolves the doc gap behind Azure Boards work item AB#25600703.

## Background
The bug (filed 2020) asked for a **simple, dedicated doc** showing how to implement the PSF **write-to-install-directory** fixup, because *"the main PSF doc is overloaded."* The bug owner later re-scoped it to *"write doc on how to use the re-direction in the PSF."*

That dedicated how-to now exists&mdash;`psf/psf-filesystem-writepermission.md` (*"How to fix Package Support Framework Filesystem Write Permission errors"*)&mdash;a focused, end-to-end walkthrough of the **FileRedirectionFixup** with `redirectedPaths.packageRelative`, listed in the TOC under *"How to implement PSF in your package"* next to the scripting docs. The core ask is delivered; the remaining gap is **discoverability**: the overloaded entry-point docs don't route readers to it.

## Change
- **`package-support-framework.md`** (Get started): added a `[!TIP]` in the *File Redirection Fixup* section linking to the dedicated write-permission how-to for customers who already know their app writes to its install directory.
- **`package-support-framework-overview.md`**: pointed the *"writes into the install folder"* bullet directly at `psf-filesystem-writepermission.md`, and the working-directory bullet at `psf-current-working-directory.md`.
- **`psf-filesystem-writepermission.md`**: added a **Related articles** section linking back to the PSF overview, get-started, and the other implement-PSF how-tos.
- Bumped `ms.date` on the edited files.

No content duplicated&mdash;this closes the navigation gap that the bug called out.