### PR TITLE
Add guidance for replacing installer-based apps with MSIX

### DIFF
--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -1,7 +1,7 @@
 ---
 description: This article provides all the details you need to manage deploying your MSIX applications in an enterprise and retail environment.  This article is targeted at enterprise and IT Pros.
 title: Manage your MSIX deployment Overview
-ms.date: 04/15/2026
+ms.date: 07/03/2026
 ms.topic: concept-article
 keywords: windows 10, deployment, msix
 ms.assetid:  
@@ -10,6 +10,8 @@ ms.assetid:
 # Manage your MSIX deployment
 
 Packaging your application is only half the battle. Next you need to be able to deploy your application to your users. How you deploy your application depends on who your customer is.  This section, Managing your MSIX deployment, will discuss deployment of MSIX packages for both enterprise and retail markets. It will provide links and tips and tricks to ensuring a successful experience. 
+
+If your users already have a version of your app installed through a classic **.exe**, **.msi**, or ClickOnce installer, see [Replace an existing installer-based app with MSIX](replace-installer-based-app-with-msix.md) for guidance on how the two installs coexist and how to remove the previous version.
 
 In order to successfully deploy MSIX, you need to consider the following:
 * Who is my customer?

--- a/msix-src/desktop/replace-installer-based-app-with-msix.md
+++ b/msix-src/desktop/replace-installer-based-app-with-msix.md
@@ -1,0 +1,68 @@
+---
+description: Guidance for replacing an existing installer-based desktop app (.exe, .msi, or ClickOnce) with its MSIX version, including how the two installs coexist, how to remove the previous version, and which deployment technology to use.
+title: Replace an existing installer-based app with MSIX
+ms.date: 07/03/2026
+ms.topic: concept-article
+keywords: windows 10, deployment, msix, migrate, replace, installer, msi, clickonce
+ms.assetid:  
+---
+
+# Replace an existing installer-based app with MSIX
+
+When you move an existing desktop application to MSIX, you often have a version already installed on your users' machines through a classic installer, such as an **.exe** setup program, a Windows Installer (**.msi**) package, or a **ClickOnce** deployment. This article explains how the MSIX version relates to that existing install, how to remove the previous version, and how to choose a deployment technology for the rollout.
+
+Before you plan the transition, package your application. For help preparing your installer for conversion, see [Know your installer](../packaging-tool/know-your-installer.md) and [Create an MSIX package](../packaging-tool/create-an-msix-overview.md).
+
+## The MSIX version installs side by side
+
+An MSIX package has a unique [package identity](../overview.md) that the operating system tracks. A classic **.exe**, **.msi**, or ClickOnce installation does not have this identity, so Windows treats the MSIX version as a separate app.
+
+Because of this, keep the following in mind:
+
+* Installing the MSIX package does **not** upgrade or remove the existing unpackaged installation. There is no in-place upgrade from a classic installer to MSIX &mdash; it is a *replace*, not an upgrade.
+* Both versions can be present on the machine at the same time, which can result in duplicate Start menu entries and file-type associations.
+* MSIX version comparison and upgrade logic (see [Manage your MSIX deployment](managing-your-msix-deployment-overview.md)) applies only between MSIX packages, not between an MSIX package and a classic installation.
+
+Plan to remove the previous version as part of your rollout so that users end up with only the MSIX version.
+
+## Remove the previous version
+
+The recommended approach is to have the MSIX version drive the removal of the older installer-based app, so that a single deployment transitions the user. There are two common patterns.
+
+### Uninstall from the new app
+
+Have your MSIX-packaged app detect the previous installation on first run and uninstall it. For example, the app can look up the legacy app's uninstall string in the registry (or the Windows Installer product code for an **.msi**) and invoke it silently.
+
+Keep these considerations in mind:
+
+* An MSIX-packaged app runs with the current user's privileges. Uninstalling a **per-user** installation works without a prompt, but silently removing a **per-machine** (all-users) **.msi** or **.exe** installation requires administrator elevation, which a packaged app can't obtain silently.
+* Only remove software that your app owns. Verify the legacy app's identity (for example, its product code or publisher) before uninstalling it.
+
+This pattern works well for consumer and retail distribution, where an IT management tool isn't available. See [Distribute your MSIX in a retail environment](managing-your-msix-deployment-retail.md).
+
+### Uninstall with your management tool
+
+In a managed environment, use your device or application management tool to remove the legacy **.exe**, **.msi**, or ClickOnce app as part of the MSIX rollout. For example, sequence an uninstall of the old application before (or alongside) the MSIX deployment in Microsoft Intune or Microsoft Configuration Manager.
+
+For details, see [Distribute your MSIX in an enterprise environment](managing-your-msix-deployment-enterprise.md), [Microsoft Intune](managing-your-msix-deployment-intune.md), and [Microsoft Configuration Manager](managing-your-msix-deployment-configmgr.md).
+
+## Choose a deployment technology
+
+How you deliver the MSIX version depends on your audience. The following options are covered in [Manage your MSIX deployment](managing-your-msix-deployment-overview.md):
+
+| Deployment technology | Best for | Learn more |
+|---|---|---|
+| Microsoft Store | Consumer apps and broad distribution | [Distribute your MSIX in a retail environment](managing-your-msix-deployment-retail.md) |
+| App Installer (web install) | Distributing and auto-updating apps from your own website | [Install MSIX with App Installer](../app-installer/app-installer-root.md) |
+| Microsoft Intune | Cloud-managed enterprise devices | [Microsoft Intune](managing-your-msix-deployment-intune.md) |
+| Microsoft Configuration Manager | On-premises managed enterprise devices | [Microsoft Configuration Manager](managing-your-msix-deployment-configmgr.md) |
+| MSIX Core | Bringing MSIX (including from a ClickOnce setup.exe) to earlier versions of Windows | [MSIX Core](../msix-core/msixcore.md) |
+
+If you're moving from ClickOnce specifically, you can also reuse a ClickOnce-style setup.exe experience to bootstrap the MSIX install on down-level Windows. See [Create an MSIX package with MSIX Core from source code](../msix-core/msixcore-clickonce-solution.md).
+
+## Related content
+
+* [Know your installer](../packaging-tool/know-your-installer.md)
+* [Manage your MSIX deployment](managing-your-msix-deployment-overview.md)
+* [Distribute your MSIX in an enterprise environment](managing-your-msix-deployment-enterprise.md)
+* [Distribute your MSIX in a retail environment](managing-your-msix-deployment-retail.md)

--- a/msix-src/packaging-tool/know-your-installer.md
+++ b/msix-src/packaging-tool/know-your-installer.md
@@ -1,7 +1,7 @@
 ---
 title: Know your installer
 description: This article lists things you need to know before packaging your desktop application. You may not need to do much to get your app ready for the packaging process.
-ms.date: 01/29/2020
+ms.date: 07/03/2026
 ms.topic: article
 keywords: msix
 ---
@@ -9,6 +9,9 @@ keywords: msix
 # Know your installer
 
 This article lists the things you need to know before you convert your existing installer into an MSIX. You might not have to do much to get your application ready for the packaging process, but if any of the items below applies to your application, you need to address it before packaging.
+
+> [!NOTE]
+> If your users already have a version of your app installed through this installer, see [Replace an existing installer-based app with MSIX](../desktop/replace-installer-based-app-with-msix.md) for guidance on transitioning them to the MSIX version.
 
 + __Your application has a service__. We support converting [applications with services](convert-an-installer-with-services.md), but its important to keep in mind the [limitations](convert-an-installer-with-services.md#known-limitations) to converting a service. After conversion, you will need admin elevation in order to install the MSIX that contains a service. You can convert an application with services beginning in version 1.2019.1220.0 of the MSIX Packaging Tool, and you can deploy the MSIX with services beginning in the spring 2020 release of Windows 10.
 

--- a/msix-src/toc.yml
+++ b/msix-src/toc.yml
@@ -272,6 +272,8 @@
   items: 
     - name: Overview
       href: desktop/managing-your-msix-deployment-overview.md
+    - name: Replace an existing installer-based app with MSIX
+      href: desktop/replace-installer-based-app-with-msix.md
     - name: Plan for your deployment
       href: desktop/managing-your-msix-deployment-targetdevices.md
     - name: Install MSIX with App Installer


### PR DESCRIPTION
Adds a new article, **Replace an existing installer-based app with MSIX**, under Manage your MSIX deployment.

Addresses a partner (Lenovo/AppConsult) request for guidance on the best way to replace an existing .exe/.msi/ClickOnce install with the MSIX version across deployment technologies. The article explains that MSIX installs side by side with the unpackaged app (separate package identity, no in-place upgrade), documents the two recommended ways to remove the previous version (app-driven uninstall and management-tool uninstall), and points to the deployment-technology options. Wired into `toc.yml` and linked from the deployment overview and Know your installer pages.

Resolves AB#25952048