### PR TITLE
Clarify App Installer file version is independent of the package version

### DIFF
--- a/msix-src/app-installer/how-to-create-appinstaller-file.md
+++ b/msix-src/app-installer/how-to-create-appinstaller-file.md
@@ -124,7 +124,7 @@ Include the `AppInstaller` element into your App Installer file noting the versi
 1. Update the `URI` attribute with the network location where this ***.AppInstaller** file will be accessible from.
 
 > [!IMPORTANT]
-> The `Version` attribute on the `AppInstaller` element is the version of the **App Installer file itself**. It's independent of the versions of the packages the file references (the `Version` attributes on the `MainPackage`, `MainBundle`, and other package elements). App Installer detects that a published update is available by comparing this file version, so you must **increment** it every time you publish a change &mdash; even when the package version stays the same or moves backward (see [Step 6](#step-6-add-update-setting)). The App Installer file version must always move forward; if it doesn't, App Installer treats the file as unchanged and won't apply the update.
+> The `Version` attribute on the `AppInstaller` element is the version of the **App Installer file itself**. It's independent of the versions of the packages the file references (the `Version` attributes on the `MainPackage`, `MainBundle`, and other package elements). App Installer detects that a published update is available by comparing this file version, so you must **increment** it every time you publish a change, even when the package version stays the same or moves backward (see [Step 6](#step-6-add-update-setting)). The App Installer file version must always move forward; if it doesn't, App Installer treats the file as unchanged and won't apply the update.
 
 
 ## Step 3: Add the main package information
@@ -277,7 +277,7 @@ The App Installer file can also specify update setting so that the related sets 
 | ForceUpdateFromAnyVersion | Specifies that the next version of the application could be to a newer or older version. If True, will all for both, if False (default), only new versions will be installed. |
 
 > [!NOTE]
-> `ForceUpdateFromAnyVersion` controls only the *package* version that App Installer will move to. It doesn't change how updates are detected. When you downgrade the referenced package (for example, from `1.1.0.0` to `1.0.0.0`), you must still **increase** the `Version` attribute on the root `AppInstaller` element &mdash; don't lower the App Installer file version to match the downgraded package. The App Installer file version is independent of the package version and must always move forward, or App Installer won't detect the change and apply the downgrade.
+> `ForceUpdateFromAnyVersion` controls only the **package** version that App Installer will move to. It doesn't change how updates are detected. When you downgrade the referenced package (for example, from `1.1.0.0` to `1.0.0.0`), you must still **increase** the `Version` attribute on the root `AppInstaller` element. Don't lower the App Installer file version to match the downgraded package. The App Installer file version is independent of the package version and must always move forward, or App Installer won't detect the change and apply the downgrade.
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/msix-src/app-installer/how-to-create-appinstaller-file.md
+++ b/msix-src/app-installer/how-to-create-appinstaller-file.md
@@ -1,7 +1,7 @@
 ---
 title: Create an App Installer file manually
 description: This article describes how to install a related set via App Installer, including how to create a *.appinstaller file that defines your related set.
-ms.date: 04/15/2026
+ms.date: 07/03/2026
 ms.topic: how-to
 keywords: windows 10, uwp, app installer, AppInstaller, sideload, related set, optional packages
 ms.custom: "RS5, seodec18"
@@ -122,6 +122,9 @@ Include the `AppInstaller` element into your App Installer file noting the versi
 
 1. Update the `Version` attribute with the version of your App Installer file 
 1. Update the `URI` attribute with the network location where this ***.AppInstaller** file will be accessible from.
+
+> [!IMPORTANT]
+> The `Version` attribute on the `AppInstaller` element is the version of the **App Installer file itself**. It's independent of the versions of the packages the file references (the `Version` attributes on the `MainPackage`, `MainBundle`, and other package elements). App Installer detects that a published update is available by comparing this file version, so you must **increment** it every time you publish a change &mdash; even when the package version stays the same or moves backward (see [Step 6](#step-6-add-update-setting)). The App Installer file version must always move forward; if it doesn't, App Installer treats the file as unchanged and won't apply the update.
 
 
 ## Step 3: Add the main package information
@@ -272,6 +275,9 @@ The App Installer file can also specify update setting so that the related sets 
 | UpdateBlocksActivation    | Defines the experience when an app update is checked for.                                                                                                                     |
 | ShowPrompt                | Defines if a window is displayed when updates are being installed, and when updates are being checked for.                                                                    |
 | ForceUpdateFromAnyVersion | Specifies that the next version of the application could be to a newer or older version. If True, will all for both, if False (default), only new versions will be installed. |
+
+> [!NOTE]
+> `ForceUpdateFromAnyVersion` controls only the *package* version that App Installer will move to. It doesn't change how updates are detected. When you downgrade the referenced package (for example, from `1.1.0.0` to `1.0.0.0`), you must still **increase** the `Version` attribute on the root `AppInstaller` element &mdash; don't lower the App Installer file version to match the downgraded package. The App Installer file version is independent of the package version and must always move forward, or App Installer won't detect the change and apply the downgrade.
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/msix-src/app-installer/update-settings.md
+++ b/msix-src/app-installer/update-settings.md
@@ -51,4 +51,4 @@ The [UpdateSettings](/uwp/schemas/appinstallerschema/element-update-settings) el
 - **ForceUpdateFromAnyVersion**: Allows the app to update from version x to version x++ or to downgrade from version x to version x--. Without this element, the app can only move to a higher version.
 
     > [!NOTE]
-    > This setting applies only to the *package* version. The `Version` attribute on the root `AppInstaller` element is independent of the package version and must always be incremented when you publish a change &mdash; including a package downgrade. If the App Installer file version doesn't move forward, App Installer treats the file as unchanged and won't apply the update.
+    > This setting applies only to the **package** version. The `Version` attribute on the root `AppInstaller` element is independent of the package version and must always be incremented when you publish a change, including a package downgrade. If the App Installer file version doesn't move forward, App Installer treats the file as unchanged and won't apply the update.

--- a/msix-src/app-installer/update-settings.md
+++ b/msix-src/app-installer/update-settings.md
@@ -1,7 +1,7 @@
 ---
 title: App Installer file update settings
 description: This article describes options for how to configure the behavior of app updates by using the App Installer file.
-ms.date: 06/12/2020
+ms.date: 07/03/2026
 ms.topic: how-to
 keywords: windows 10, uwp, msix
 ms.custom: RS5
@@ -49,3 +49,6 @@ The [UpdateSettings](/uwp/schemas/appinstallerschema/element-update-settings) el
 - **AutomaticBackgroundTask**: Checks for updates in the background every 8 hours independently of whether the user launched the app. This type of update cannot show UI.
 
 - **ForceUpdateFromAnyVersion**: Allows the app to update from version x to version x++ or to downgrade from version x to version x--. Without this element, the app can only move to a higher version.
+
+    > [!NOTE]
+    > This setting applies only to the *package* version. The `Version` attribute on the root `AppInstaller` element is independent of the package version and must always be incremented when you publish a change &mdash; including a package downgrade. If the App Installer file version doesn't move forward, App Installer treats the file as unchanged and won't apply the update.


### PR DESCRIPTION
Clarifies that the `.appinstaller` file's root `Version` attribute is the version of the App Installer **file itself**, independent of the referenced package versions, and that it must always move forward for App Installer to detect and apply a published change.

Addresses a customer issue where a package downgrade (1.1.0.0 -> 1.0.0.0) wasn't applied because the App Installer file `Version` was also lowered to 1.0.0.0 to match the package. Adds an `[!IMPORTANT]` note at Step 2 and an `[!NOTE]` at Step 6 in `how-to-create-appinstaller-file.md`, plus a matching note on the `ForceUpdateFromAnyVersion` entry in `update-settings.md`.

Resolves AB#27479263