### PR TITLE
Define what a footprint file is

### DIFF
--- a/msix-src/msix-core/msixcore-troubleshoot.md
+++ b/msix-src/msix-core/msixcore-troubleshoot.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Tips 
 description: This article list out the error codes and issues that customers may face when working with MSIX Core 
-ms.date: 11/15/2019
+ms.date: 07/03/2026
 ms.topic: troubleshooting-general
 keywords: windows 10, windows 7, windows 8, Windows Server, uwp, msix, msixcore, 1709, 1703, 1607, 1511, 1507
 ms.custom: "RS5, seodec18"
@@ -32,6 +32,9 @@ The following errors occur when there is an issue with the package format.
 | 0x8BAD0035 | DuplicateFootprintFile |
 | 0x8BAD0036 | UnknownFileNameEncoding |
 | 0x8BAD0037 | DuplicateFile |
+
+> [!NOTE]
+> Several of these errors refer to *footprint files*. Footprint files are the reserved files that describe the package itself, rather than the app payload (your executables, DLLs, and assets). They include the package manifest (`AppxManifest.xml`), the block map (`AppxBlockMap.xml`), the package signature (`AppxSignature.p7x`), the code integrity catalog (`AppxMetadata\CodeIntegrity.cat`), and the content group map (`AppxContentGroupMap.xml`). A package must contain exactly one of each required footprint file; a `DuplicateFootprintFile` error means the package contains more than one.
 
 The following errors are related to file issues
 

--- a/msix-src/package/create-cgm.md
+++ b/msix-src/package/create-cgm.md
@@ -2,7 +2,7 @@
 ms.assetid: ff2523cb-8109-42be-9dfc-cb5d09002574
 title: Create and convert a source content group map
 description: This article describes how to create a content group map. A content group map necessary to get your app ready for streaming install.
-ms.date: 07/02/2019
+ms.date: 07/03/2026
 author: andreww-msft
 ms.author: jken
 ms.topic: how-to
@@ -92,7 +92,9 @@ Adding the single wildcard file name will include files added to the project dir
 
 Note that you cannot use the double wild card, "**", at the root of the file structure to include every file in the project since this will fail when attempting to convert `SourceAppxContentGroupMap.xml` to the final `AppxContentGroupMap.xml`.
 
-It's also important to note that footprint files (AppxManifest.xml, AppxSignature.p7x, resources.pri, etc.) should not be included in the content group map. If footprint files are included within one of the wildcard file names you specify, they will be ignored.
+It's also important to note that footprint files should not be included in the content group map. If footprint files are included within one of the wildcard file names you specify, they will be ignored.
+
+*Footprint files* are the reserved files that describe the package itself, rather than the app payload (your executables, DLLs, and assets). They include the package manifest (`AppxManifest.xml`), the block map (`AppxBlockMap.xml`), the package signature (`AppxSignature.p7x`), the code integrity catalog (`AppxMetadata\CodeIntegrity.cat`), and the content group map (`AppxContentGroupMap.xml`). The package resource index (`resources.pri`) is also generated and managed as part of the package structure. Because Windows manages these files, you don't list them as content in the content group map.
 
 ### Automatic content groups
 


### PR DESCRIPTION
Both `create-cgm.md` and `msixcore-troubleshoot.md` referenced *footprint files* without defining the term.

Adds an authoritative definition (matching the [`APPX_FOOTPRINT_FILE_TYPE`](https://learn.microsoft.com/windows/win32/api/appxpackaging/ne-appxpackaging-appx_footprint_file_type) enumeration): footprint files are the reserved files that describe the package itself &mdash; the manifest, block map, signature, code integrity catalog, and content group map &mdash; as distinct from the app payload.

- `create-cgm.md`: expands the footprint-files sentence into a definition.
- `msixcore-troubleshoot.md`: adds a `[!NOTE]` under the package-format error table explaining footprint files and the `DuplicateFootprintFile` error.

Resolves AB#29731098