### PR TITLE
Describe what app state is in the Store update flow

### DIFF
--- a/msix-src/store-developer-package-update.md
+++ b/msix-src/store-developer-package-update.md
@@ -75,9 +75,9 @@ private async void DownloadUpdatesAsync()
 
 ### Install updates
 
-Installing a package update replaces your app's files, so the system closes the app to apply it. The `RequestDownloadAndInstallStorePackageUpdatesAsync` call below terminates the running app as part of the install. Before you start the install, save your *app state* so the user can resume where they left off after the app relaunches.
+Installing a package update replaces your app's files, so the system closes the app to apply it. The `RequestDownloadAndInstallStorePackageUpdatesAsync` call below terminates the running app as part of the install. Before you start the install, save your app state so the user can resume where they left off after the app relaunches.
 
-*App state* is your app's runtime and session data &mdash; anything the user would lose if the app closed unexpectedly, such as an open document, unsaved form input, the current page or navigation position, and in-memory settings. It's distinct from the app binaries that the update replaces. Persist app state to the app's data store (for example, `ApplicationData.Current.LocalSettings` or the app's local folder) before calling the install API, then reload it the next time the app starts. For more information, see [Store and retrieve settings and other app data](/windows/apps/develop/data/store-and-retrieve-app-data).
+App state is your app's runtime and session data: anything the user would lose if the app closed unexpectedly, such as an open document, unsaved form input, the current page or navigation position, and in-memory settings. It's distinct from the app binaries that the update replaces. Persist app state to the app's data store (for example, `ApplicationData.Current.LocalSettings` or the app's local folder) before calling the install API, then reload it the next time the app starts. For more information, see [Store and retrieve settings and other app data](/windows/apps/develop/data/store-and-retrieve-app-data).
 
 ```csharp
 private async void InstallUpdatesAsync()

--- a/msix-src/store-developer-package-update.md
+++ b/msix-src/store-developer-package-update.md
@@ -2,7 +2,7 @@
 title: Update Store-published apps from your code 
 description: Describes how MSIX packages can be updated by developers in code. 
 author: Huios
-ms.date: 01/24/2020
+ms.date: 07/03/2026
 ms.topic: how-to
 keywords: windows 10, uwp, app package, app update, msix, appx
 ms.custom: "RS5, seodec18"
@@ -74,6 +74,10 @@ private async void DownloadUpdatesAsync()
 ```
 
 ### Install updates
+
+Installing a package update replaces your app's files, so the system closes the app to apply it. The `RequestDownloadAndInstallStorePackageUpdatesAsync` call below terminates the running app as part of the install. Before you start the install, save your *app state* so the user can resume where they left off after the app relaunches.
+
+*App state* is your app's runtime and session data &mdash; anything the user would lose if the app closed unexpectedly, such as an open document, unsaved form input, the current page or navigation position, and in-memory settings. It's distinct from the app binaries that the update replaces. Persist app state to the app's data store (for example, `ApplicationData.Current.LocalSettings` or the app's local folder) before calling the install API, then reload it the next time the app starts. For more information, see [Store and retrieve settings and other app data](/windows/apps/develop/data/store-and-retrieve-app-data).
 
 ```csharp
 private async void InstallUpdatesAsync()


### PR DESCRIPTION
The **Install updates** code snippet in `store-developer-package-update.md` had a `// Save app state here` comment followed by `// Under normal circumstances, app will terminate here`, but the doc never explained what *app state* is or why it matters.

Installing a Store package update via `RequestDownloadAndInstallStorePackageUpdatesAsync` terminates the app to replace its files, so unsaved runtime/session data is lost unless the developer persists it first. Adds an explanatory paragraph to the Install updates section defining app state and how it applies, with a link to [Store and retrieve settings and other app data](https://learn.microsoft.com/windows/apps/develop/data/store-and-retrieve-app-data).

Resolves AB#29731150