### PR TITLE
Explain how MSIX deployment works (staging and registration)

### DIFF
--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -40,7 +40,7 @@ Though MSIX has a 99.96% successful install rate, you still need to plan how to 
 
 ## How MSIX deployment works: staging and registration
 
-To plan deployments&mdash;especially on multi-user machines&mdash;it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: **staging** and **registration**. The sections below explain those two operations, then show how they combine to support *provisioning* (installing an app for every user) and how updates reach other users on the machine.
+To plan deployments, especially on multi-user machines, it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: **staging** and **registration**. The sections below explain those two operations, then show how they combine to support *provisioning* (installing an app for every user) and how updates reach other users on the machine.
 
 ### Staging
 
@@ -64,4 +64,4 @@ Windows also registers provisioned packages automatically the next time each use
 
 ### How updates reach other users
 
-When a package is updated, it's staged and registered for the user who triggered the update. **Every other user who has the app registered also ends up with the newer version**&mdash;typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).
+When a package is updated, it's staged and registered for the user who triggered the update. **Every other user who has the app registered also ends up with the newer version**, typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).

--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -1,7 +1,7 @@
 ---
 description: This article provides all the details you need to manage deploying your MSIX applications in an enterprise and retail environment.  This article is targeted at enterprise and IT Pros.
 title: Manage your MSIX deployment Overview
-ms.date: 07/03/2026
+ms.date: 07/12/2026
 ms.topic: concept-article
 keywords: windows 10, deployment, msix
 ms.assetid:  
@@ -40,7 +40,7 @@ Though MSIX has a 99.96% successful install rate, you still need to plan how to 
 
 ## How MSIX deployment works: staging and registration
 
-To plan deployments&mdash;especially on multi-user machines&mdash;it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: **staging** and **registration**.
+To plan deployments&mdash;especially on multi-user machines&mdash;it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: **staging** and **registration**. The sections below explain those two operations, then show how they combine to support *provisioning* (installing an app for every user) and how updates reach other users on the machine.
 
 ### Staging
 
@@ -60,8 +60,8 @@ Because staging and registration are separate, the same staged package can be re
 1. Set a flag indicating the package should be registered for all users, then
 1. Raise an event telling the system to register the provisioned package for users who are already signed in.
 
-Windows also registers provisioned packages automatically the next time each user signs in. Note that if a package has already been provisioned for a user and that user uninstalls it, it isn't automatically reinstalled for them&mdash;re-provisioning the package resets this. For the tools used to provision packages (DISM, provisioning packages, and PowerShell), see [Preinstalling packaged apps](deploy-preinstalled-apps.md).
+Windows also registers provisioned packages automatically the next time each user signs in. Note that if a package has already been provisioned for a user and that user uninstalls it, it isn't automatically reinstalled for them. On Windows 10, version 2004 and later, re-provisioning the package reinstalls it; on earlier versions, an administrator must *force provision* it. For the tools used to provision packages (DISM, provisioning packages, and PowerShell), see [Preinstalling packaged apps](deploy-preinstalled-apps.md).
 
 ### How updates reach other users
 
-When a package is updated, it's staged and registered for the user who triggered the update. **Every other user of the machine also ends up with the newer version registered for them**&mdash;typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).
+When a package is updated, it's staged and registered for the user who triggered the update. **Every other user who has the app registered also ends up with the newer version**&mdash;typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).

--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -40,28 +40,28 @@ Though MSIX has a 99.96% successful install rate, you still need to plan how to 
 
 ## How MSIX deployment works: staging and registration
 
-To plan deployments, especially on multi-user machines, it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: **staging** and **registration**. The sections below explain those two operations, then show how they combine to support *provisioning* (installing an app for every user) and how updates reach other users on the machine.
+To plan deployments, especially on multi-user machines, it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: staging and registration. The sections below explain those two operations, then show how they combine to support provisioning (installing an app for every user) and how updates reach other users on the machine.
 
 ### Staging
 
-Staging places the package's files in the correct location on the machine (under `%ProgramFiles%\WindowsApps`). Staging happens **once per machine**, regardless of how many users will ultimately use the app, and it doesn't require a user to be signed in. Because the payload is shared, staging the same package for a second user doesn't copy the files again.
+Staging places the package's files in the correct location on the machine (under `%ProgramFiles%\WindowsApps`). Staging happens once per machine, regardless of how many users will ultimately use the app, and it doesn't require a user to be signed in. Because the payload is shared, staging the same package for a second user doesn't copy the files again.
 
 ### Registration
 
-Registration sets up the package for a **specific user** so that user is ready to run it. It creates the user's app data, wires up file type associations, and adds Start menu entries. Registration is performed **once per user** and can only happen while that user is signed in.
+Registration sets up the package for a specific user so that user is ready to run it. It creates the user's app data, wires up file type associations, and adds Start menu entries. Registration is performed once per user and can only happen while that user is signed in.
 
 Because staging and registration are separate, the same staged package can be registered for many users without re-copying its files.
 
 ### Provisioning
 
-*Provisioning* is how you make a package install automatically for every user of a device. Provisioning does little more than:
+Provisioning is how you make a package install automatically for every user of a device. Provisioning does little more than:
 
 1. Stage the package, then
 1. Set a flag indicating the package should be registered for all users, then
 1. Raise an event telling the system to register the provisioned package for users who are already signed in.
 
-Windows also registers provisioned packages automatically the next time each user signs in. Note that if a package has already been provisioned for a user and that user uninstalls it, it isn't automatically reinstalled for them. On Windows 10, version 2004 and later, re-provisioning the package reinstalls it; on earlier versions, an administrator must *force provision* it. For the tools used to provision packages (DISM, provisioning packages, and PowerShell), see [Preinstalling packaged apps](deploy-preinstalled-apps.md).
+Windows also registers provisioned packages automatically the next time each user signs in. Note that if a package has already been provisioned for a user and that user uninstalls it, it isn't automatically reinstalled for them. On Windows 10, version 2004 and later, re-provisioning the package reinstalls it; on earlier versions, an administrator must force provision it. For the tools used to provision packages (DISM, provisioning packages, and PowerShell), see [Preinstalling packaged apps](deploy-preinstalled-apps.md).
 
 ### How updates reach other users
 
-When a package is updated, it's staged and registered for the user who triggered the update. **Every other user who has the app registered also ends up with the newer version**, typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).
+When a package is updated, it's staged and registered for the user who triggered the update. Every other user who has the app registered also ends up with the newer version, typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).

--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -12,35 +12,43 @@ ms.assetid:
 Packaging your application is only half the battle. Next you need to be able to deploy your application to your users. How you deploy your application depends on who your customer is.  This section, Managing your MSIX deployment, will discuss deployment of MSIX packages for both enterprise and retail markets. It will provide links and tips and tricks to ensuring a successful experience. 
 
 In order to successfully deploy MSIX, you need to consider the following:
+
 * Who is my customer?
 * What dependencies do I have?
 * How will I provide the best support for my customer?
 
 ## Who is my customer?
+
 How you deploy often depends on who is your customer and your role as a developer or administrator.   It is important to identify your role to know what tools to use.
 
 ### IT Pros
+
 IT Pros typically use a software management system to install and manage their apps.  In the [Distribute your MSIX in an enterprise environment](managing-your-msix-deployment-enterprise.md) section we will discuss:
+
 * Using Microsoft Configuration Manager and Intune to manage your apps
 * Using provisioning and DISM to preconfigure machines with MSIX
 * Controlling app access with Group Policies and AppLocker
 * Distributing apps through the web or Microsoft Intune
 
 ### Developers
+
 Developers have different tools to distribute their applications.  In the [Distribute your MSIX in a retail environment](managing-your-msix-deployment-retail.md) section we will discuss:  
+
 * Microsoft Store
 * Web Installer
 * Using GitHub Actions or Azure Pipelines for CI/CD (App Center retired March 2025)
 
 ## Dependencies
-MSIX is a robust and reliable modern app install experience. The MSIX experience delivers a 99.96% successful install rate.  But there are some caveats. MSIX is not supported by default on all versions of Windows, and the supported feature set may very depending on which version of Windows 10 you are deploying to.  In the [Plan for your deployment](managing-your-msix-deployment-targetdevices.md) section we will discuss the importance of understanding the target device that the MSIX will be deployed to. 
+
+MSIX is a robust and reliable modern app install experience. The MSIX experience delivers a 99.96% successful install rate.  But there are some caveats. MSIX is not supported by default on all versions of Windows, and the supported feature set may very depending on which version of Windows 10 you are deploying to.  In the [Plan for your deployment](managing-your-msix-deployment-targetdevices.md) section we will discuss the importance of understanding the target device that the MSIX will be deployed to.
 
 ## Providing support for my customer
+
 Though MSIX has a 99.96% successful install rate, you still need to plan how to support your customer.  In the [MSIX Validation and Troubleshooting section](managing-your-msix-deployment-troubleshooting.md) we discuss tools available for you to diagnose installation issues.
 
-## How MSIX deployment works: staging and registration
+## MSIX Install operations
 
-To plan deployments, especially on multi-user machines, it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: staging and registration. The sections below explain those two operations, then show how they combine to support provisioning (installing an app for every user) and how updates reach other users on the machine.
+To plan deployments, especially on multi-user machines, it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: staging and registration.
 
 ### Staging
 
@@ -51,6 +59,10 @@ Staging places the package's files in the correct location on the machine (under
 Registration sets up the package for a specific user so that user is ready to run it. It creates the user's app data, wires up file type associations, and adds Start menu entries. Registration is performed once per user and can only happen while that user is signed in.
 
 Because staging and registration are separate, the same staged package can be registered for many users without re-copying its files.
+
+## How MSIX deployment works
+
+The sections below explain how the Staging and Registration operations combine to support provisioning (installing an app for every user) and how updates reach other users on the machine.
 
 ### Provisioning
 

--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -46,7 +46,7 @@ MSIX is a robust and reliable modern app install experience. The MSIX experience
 
 Though MSIX has a 99.96% successful install rate, you still need to plan how to support your customer.  In the [MSIX Validation and Troubleshooting section](managing-your-msix-deployment-troubleshooting.md) we discuss tools available for you to diagnose installation issues.
 
-## MSIX Install operations
+## MSIX install operations
 
 To plan deployments, especially on multi-user machines, it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: staging and registration.
 
@@ -60,9 +60,9 @@ Registration sets up the package for a specific user so that user is ready to ru
 
 Because staging and registration are separate, the same staged package can be registered for many users without re-copying its files.
 
-## How MSIX deployment works
+## Provisioning and updates across users
 
-The sections below explain how the Staging and Registration operations combine to support provisioning (installing an app for every user) and how updates reach other users on the machine.
+The sections below explain how the staging and registration operations combine to support provisioning (installing an app for every user) and how updates reach other users on the machine.
 
 ### Provisioning
 

--- a/msix-src/desktop/managing-your-msix-deployment-overview.md
+++ b/msix-src/desktop/managing-your-msix-deployment-overview.md
@@ -1,7 +1,7 @@
 ---
 description: This article provides all the details you need to manage deploying your MSIX applications in an enterprise and retail environment.  This article is targeted at enterprise and IT Pros.
 title: Manage your MSIX deployment Overview
-ms.date: 04/15/2026
+ms.date: 07/03/2026
 ms.topic: concept-article
 keywords: windows 10, deployment, msix
 ms.assetid:  
@@ -38,5 +38,30 @@ MSIX is a robust and reliable modern app install experience. The MSIX experience
 ## Providing support for my customer
 Though MSIX has a 99.96% successful install rate, you still need to plan how to support your customer.  In the [MSIX Validation and Troubleshooting section](managing-your-msix-deployment-troubleshooting.md) we discuss tools available for you to diagnose installation issues.
 
+## How MSIX deployment works: staging and registration
 
- 
+To plan deployments&mdash;especially on multi-user machines&mdash;it helps to understand what Windows does under the covers when a package is installed. Installing an MSIX package is really two distinct operations: **staging** and **registration**.
+
+### Staging
+
+Staging places the package's files in the correct location on the machine (under `%ProgramFiles%\WindowsApps`). Staging happens **once per machine**, regardless of how many users will ultimately use the app, and it doesn't require a user to be signed in. Because the payload is shared, staging the same package for a second user doesn't copy the files again.
+
+### Registration
+
+Registration sets up the package for a **specific user** so that user is ready to run it. It creates the user's app data, wires up file type associations, and adds Start menu entries. Registration is performed **once per user** and can only happen while that user is signed in.
+
+Because staging and registration are separate, the same staged package can be registered for many users without re-copying its files.
+
+### Provisioning
+
+*Provisioning* is how you make a package install automatically for every user of a device. Provisioning does little more than:
+
+1. Stage the package, then
+1. Set a flag indicating the package should be registered for all users, then
+1. Raise an event telling the system to register the provisioned package for users who are already signed in.
+
+Windows also registers provisioned packages automatically the next time each user signs in. Note that if a package has already been provisioned for a user and that user uninstalls it, it isn't automatically reinstalled for them&mdash;re-provisioning the package resets this. For the tools used to provision packages (DISM, provisioning packages, and PowerShell), see [Preinstalling packaged apps](deploy-preinstalled-apps.md).
+
+### How updates reach other users
+
+When a package is updated, it's staged and registered for the user who triggered the update. **Every other user of the machine also ends up with the newer version registered for them**&mdash;typically the next time the package is registered for them (for example, at their next sign-in). In other words, if a package is updated for one user, you can assume the same version will apply to all other users in the near future. For how the platform minimizes what's downloaded during an update, see [App package updates](../app-package-updates.md).


### PR DESCRIPTION
## Summary

Adds a **How MSIX deployment works: staging and registration** concept section to `msix-src/desktop/managing-your-msix-deployment-overview.md`, providing the more advanced deployment explanation requested in this bug.

The new section covers the platform model described by the MSIX team in the work item:
- **Staging** &mdash; placing package files under `%ProgramFiles%\WindowsApps`, done once per machine and without a signed-in user.
- **Registration** &mdash; per-user setup (app data, file type associations, Start entries), done once per user at sign-in.
- **Provisioning** &mdash; stage + set the all-user registration flag + raise the event; auto-registers at each user's next sign-in; a user-uninstalled provisioned app isn't auto-reinstalled unless re-provisioned.
- **How updates reach other users** &mdash; an update applied for one user propagates to every other user of the machine (typically at their next registration/sign-in).

Cross-links to **Preinstalling packaged apps** (provisioning tools) and **App package updates** (differential download). Placed at the end of the file to avoid overlapping with the still-open PR #484, which edits the intro of the same document.

Resolves AB#36938354