### PR TITLE
Fix App Installer UpdateUris/RepairUris element docs

### DIFF
--- a/msix-src/app-installer/auto-update-and-repair--overview.md
+++ b/msix-src/app-installer/auto-update-and-repair--overview.md
@@ -27,7 +27,7 @@ The Windows Settings App provides the ability to enable / disable the automatic 
 
 ## Automatic updates
 
-Windows apps will use their App Installer URI path to check for Windows app updates, however if the App Installer URI is inaccessible the Windows app will check for updates using the [`UpdateUris`](/uwp/schemas/appinstallerschema/element-s4-updateuris), attempting to connect to each before attempting the next. The first App Installer file to be accessible will be validated against checking for any new Windows app updates.
+An MSIX package that was installed from an App Installer file checks for updates by reopening that same App Installer file at its published URI. If that URI is not reachable, App Installer falls back to the [`UpdateUris`](/uwp/schemas/appinstallerschema/element-s4-updateuris) list and tries each URI in turn until one responds. The first App Installer file it can reach is used to check the package for a newer version.
 
 Updating of Windows apps supports the following elements:
 

--- a/msix-src/app-installer/auto-update-and-repair--overview.md
+++ b/msix-src/app-installer/auto-update-and-repair--overview.md
@@ -1,7 +1,7 @@
 ---
 title: Auto-update and repair apps
 description: Overview of the auto-update and repair settings for Windows apps installed using an AppInstaller file.
-ms.date: 04/10/2026
+ms.date: 07/04/2026
 ms.topic: article
 keywords: windows 10, windows 11, uwp, app installer, AppInstaller, auto-update, auto-repair
 ---
@@ -27,7 +27,7 @@ The Windows Settings App provides the ability to enable / disable the automatic 
 
 ## Automatic updates
 
-Windows apps will use their App Installer URI path to check for Windows app updates, however if the App Installer URI is inaccessible the Windows app will check for updates using the UpdateURIs, attempting to connect to each before attempting the next. The first App Installer file to be accessible will be validated against checking for any new Windows app updates.
+Windows apps will use their App Installer URI path to check for Windows app updates, however if the App Installer URI is inaccessible the Windows app will check for updates using the [UpdateUris](/uwp/schemas/appinstallerschema/element-s4-updateuris), attempting to connect to each before attempting the next. The first App Installer file to be accessible will be validated against checking for any new Windows app updates.
 
 Updating of Windows apps supports the following elements:
 
@@ -36,7 +36,7 @@ Updating of Windows apps supports the following elements:
 | HoursBetweenUpdateChecks | Defines the minimal gap in Windows app update checks.                                                                           |
 | UpdateBlocksActivation   | Defines the experience when an app update is checked for.                                                                       |
 | ShowPrompt               | Defines if a window is displayed when updates are being installed, and when updates are being checked for.                      |
-| UpdateURI                | The URI to the fallback App Installer file which can be used to update the Windows app when the App Installer URI is unavailable. |
+| [UpdateUri](/uwp/schemas/appinstallerschema/element-s4-updateuri) | The URI to the fallback App Installer file which can be used to update the Windows app when the App Installer URI is unavailable. |
 
 For instructions on how to create an App Installer file with the above settings, please visit the [Creating an App Installer file](how-to-create-appinstaller-file.md) Docs article.
 
@@ -82,11 +82,11 @@ For more information on the CSP, please visit the [Enterprise Modern App Managem
 
 ## Automatic Repair
 
-Windows apps will use their App Installer URI path to identify where the Windows app can source it's repair from. If the App Installer URI is inaccessible or not configured, it will then attempt to access a Windows app file from the `RepairURIs`. 
+Windows apps will use their App Installer URI path to identify where the Windows app can source it's repair from. If the App Installer URI is inaccessible or not configured, it will then attempt to access a Windows app file from the [`RepairUris`](/uwp/schemas/appinstallerschema/element-s4-repairuris). 
 
 | Elements  | Description                                                                                                                     |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------|
-| UpdateURI | The URI to the fallback App Installer file which can be used to update the Windows app when the App Installer URI is unavailable. |
+| [RepairUri](/uwp/schemas/appinstallerschema/element-s4-repairuri) | The URI to a Windows app or App Installer file used to repair the Windows app when the App Installer URI is inaccessible or not configured. |
 
 For more information on how to create an *.AppInstaller file, see [How to create an App Installer file](how-to-create-appinstaller-file.md) or download and use the [App Installer File Builder](https://aka.ms/msix-toolkit) as part of the MSIX Toolkit.
 

--- a/msix-src/app-installer/auto-update-and-repair--overview.md
+++ b/msix-src/app-installer/auto-update-and-repair--overview.md
@@ -27,7 +27,7 @@ The Windows Settings App provides the ability to enable / disable the automatic 
 
 ## Automatic updates
 
-Windows apps will use their App Installer URI path to check for Windows app updates, however if the App Installer URI is inaccessible the Windows app will check for updates using the [UpdateUris](/uwp/schemas/appinstallerschema/element-s4-updateuris), attempting to connect to each before attempting the next. The first App Installer file to be accessible will be validated against checking for any new Windows app updates.
+Windows apps will use their App Installer URI path to check for Windows app updates, however if the App Installer URI is inaccessible the Windows app will check for updates using the [`UpdateUris`](/uwp/schemas/appinstallerschema/element-s4-updateuris), attempting to connect to each before attempting the next. The first App Installer file to be accessible will be validated against checking for any new Windows app updates.
 
 Updating of Windows apps supports the following elements:
 
@@ -36,7 +36,7 @@ Updating of Windows apps supports the following elements:
 | HoursBetweenUpdateChecks | Defines the minimal gap in Windows app update checks.                                                                           |
 | UpdateBlocksActivation   | Defines the experience when an app update is checked for.                                                                       |
 | ShowPrompt               | Defines if a window is displayed when updates are being installed, and when updates are being checked for.                      |
-| [UpdateUri](/uwp/schemas/appinstallerschema/element-s4-updateuri) | The URI to the fallback App Installer file which can be used to update the Windows app when the App Installer URI is unavailable. |
+| [`UpdateUri`](/uwp/schemas/appinstallerschema/element-s4-updateuri) | The URI to the fallback App Installer file which can be used to update the Windows app when the App Installer URI is unavailable. |
 
 For instructions on how to create an App Installer file with the above settings, please visit the [Creating an App Installer file](how-to-create-appinstaller-file.md) Docs article.
 
@@ -86,7 +86,7 @@ Windows apps will use their App Installer URI path to identify where the Windows
 
 | Elements  | Description                                                                                                                     |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------|
-| [RepairUri](/uwp/schemas/appinstallerschema/element-s4-repairuri) | The URI to a Windows app or App Installer file used to repair the Windows app when the App Installer URI is inaccessible or not configured. |
+| [`RepairUri`](/uwp/schemas/appinstallerschema/element-s4-repairuri) | The URI to a Windows app or App Installer file used to repair the Windows app when the App Installer URI is inaccessible or not configured. |
 
 For more information on how to create an *.AppInstaller file, see [How to create an App Installer file](how-to-create-appinstaller-file.md) or download and use the [App Installer File Builder](https://aka.ms/msix-toolkit) as part of the MSIX Toolkit.
 

--- a/msix-src/app-installer/how-to-create-appinstaller-file.md
+++ b/msix-src/app-installer/how-to-create-appinstaller-file.md
@@ -1,7 +1,7 @@
 ---
 title: Create an App Installer file manually
 description: This article describes how to install a related set via App Installer, including how to create a *.appinstaller file that defines your related set.
-ms.date: 04/15/2026
+ms.date: 07/04/2026
 ms.topic: how-to
 keywords: windows 10, uwp, app installer, AppInstaller, sideload, related set, optional packages
 ms.custom: "RS5, seodec18"
@@ -39,7 +39,7 @@ Following the steps provided above, you will have successfully created an App In
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <AppInstaller
-    xmlns="http://schemas.microsoft.com/appx/appinstaller/2017/2"
+    xmlns="http://schemas.microsoft.com/appx/appinstaller/2021"
     Version="1.0.0.0"
     Uri="http://mywebservice.azurewebsites.net/appset.appinstaller" >
 
@@ -70,19 +70,19 @@ Following the steps provided above, you will have successfully created an App In
             ProcessorArchitecture="x64" />
     </OptionalPackages>
 
-    <UpdateURIs>
-        <UpdateURI>http://mywebservice.azurewebsites.net/appset.appinstaller</UpdateURI>
-        <UpdateURI>http://mywebservice2.azurewebsites.net/appset.appinstaller</UpdateURI>
-    </UpdateURIs>
-
-    <RepairURIs>
-        <RepairURI>http://mywebservice.azurewebsites.net/appset.appinstaller</RepairURI>
-        <RepairURI>http://mywebservice2.azurewebsites.net/appset.appinstaller</RepairURI>
-    </RepairURIs>
-
     <UpdateSettings>
-        <OnLaunch HoursBetweenUpdateChecks="0"/>   
+        <OnLaunch HoursBetweenUpdateChecks="0"/>
     </UpdateSettings>
+
+    <UpdateUris>
+        <UpdateUri>http://mywebservice.azurewebsites.net/appset.appinstaller</UpdateUri>
+        <UpdateUri>http://mywebservice2.azurewebsites.net/appset.appinstaller</UpdateUri>
+    </UpdateUris>
+
+    <RepairUris>
+        <RepairUri>http://mywebservice.azurewebsites.net/appset.appinstaller</RepairUri>
+        <RepairUri>http://mywebservice2.azurewebsites.net/appset.appinstaller</RepairUri>
+    </RepairUris>
 
 </AppInstaller>
 ```
@@ -335,11 +335,13 @@ The Update URIs must target App Installer files.
 </AppInstaller>
 ```
 
+For schema details, see the [s4:UpdateUris](/uwp/schemas/appinstallerschema/element-s4-updateuris) (container) and [s4:UpdateUri](/uwp/schemas/appinstallerschema/element-s4-updateuri) (item) reference.
+
 ## Step 8: Add Auto Repair Settings
 >[!Important]
 >The following settings require the 2021 schema version in your `.appinstaller` file and Windows 10, version 2004 (build 19041) or later.
 
-These settings enable repair of the Windows app when it has become tampered with. The source installer used to repair the app can be configured using the `<RepairURIs>` property. The Windows app will attempt to repair itself based on the App Installer URI; if inaccessible, it will use the Repair URIs to identify a repair source. A maximum of 10 Repair URIs can be configured for any Windows app.
+These settings enable repair of the Windows app when it has become tampered with. The source installer used to repair the app can be configured using the `<RepairUris>` property. The Windows app will attempt to repair itself based on the App Installer URI; if inaccessible, it will use the Repair URIs to identify a repair source. A maximum of 10 Repair URIs can be configured for any Windows app.
 
 The Repair URIs can target Windows apps or App Installer files. This setting does not require that the Windows app have been installed using an App Installer file.
 
@@ -368,6 +370,8 @@ The Repair URIs can target Windows apps or App Installer files. This setting doe
 
 </AppInstaller>
 ```
+
+For schema details, see the [s4:RepairUris](/uwp/schemas/appinstallerschema/element-s4-repairuris) (container) and [s4:RepairUri](/uwp/schemas/appinstallerschema/element-s4-repairuri) (item) reference.
 
 For all of the details on the XML schema, see [App Installer file reference](/uwp/schemas/appinstallerschema/app-installer-file).
 

--- a/msix-src/app-installer/how-to-create-appinstaller-file.md
+++ b/msix-src/app-installer/how-to-create-appinstaller-file.md
@@ -302,7 +302,7 @@ The App Installer file can also specify update setting so that the related sets 
 >[!Important]
 >The following settings require the 2021 schema version in your `.appinstaller` file and Windows 10, version 2004 (build 19041) or later.
 
-These settings allow updating the Windows app from the App Installer URI, adhering to the configurations set in the previous step. The Update URIs configured in this step will act as fallback URIs that can be used if the original App Installer URI is no longer accessible. A maximum of 10 Update URIs can be configured for any Windows app.
+These settings allow updating the MSIX package from the App Installer URI, adhering to the configurations set in the previous step. The Update URIs configured in this step act as fallback URIs that can be used if the original App Installer URI is no longer accessible. A maximum of 10 Update URIs can be configured for any package.
 
 The Update URIs must target App Installer files.
 
@@ -341,9 +341,9 @@ For schema details, see the [s4:UpdateUris](/uwp/schemas/appinstallerschema/elem
 >[!Important]
 >The following settings require the 2021 schema version in your `.appinstaller` file and Windows 10, version 2004 (build 19041) or later.
 
-These settings enable repair of the Windows app when it has become tampered with. The source installer used to repair the app can be configured using the `<RepairUris>` property. The Windows app will attempt to repair itself based on the App Installer URI; if inaccessible, it will use the Repair URIs to identify a repair source. A maximum of 10 Repair URIs can be configured for any Windows app.
+These settings enable repair of the MSIX package when it has become tampered with. The source installer used to repair the package can be configured using the `<RepairUris>` property. The package will attempt to repair itself based on the App Installer URI; if that URI is inaccessible, it will use the Repair URIs to identify a repair source. A maximum of 10 Repair URIs can be configured for any package.
 
-The Repair URIs can target Windows apps or App Installer files. This setting does not require that the Windows app have been installed using an App Installer file.
+The Repair URIs can target MSIX packages or App Installer files. This setting does not require that the package have been installed using an App Installer file.
 
 ``` xml
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Resolves the documentation defects for the App Installer auto-update/repair elements (`UpdateUris`/`UpdateUri`/`RepairUris`/`RepairUri`).

## What & why
The bug asked for element reference documentation for `UpdateURIs`/`UpdateURI`/`RepairURIs`/`RepairURI`. The formal schema *reference* pages now exist in the schema docset (`/uwp/schemas/appinstallerschema/element-s4-updateuris` and siblings, maintained in the winrt-related repo). Within msix-docs the actionable gaps were correctness defects in the **conceptual** App Installer pages for these exact elements:

- **Wrong casing.** `UpdateURIs`/`UpdateURI`/`RepairURIs`/`RepairURI` corrected to the canonical `UpdateUris`/`UpdateUri`/`RepairUris`/`RepairUri`. XML is case-sensitive, and the authoritative 2021 schema uses "Uris"/"Uri".
- **Schema-invalid overview example.** The "Example of an App Installer file" declared the `2017/2` namespace but used 2021-only `UpdateURIs`/`RepairURIs` elements, in the wrong order. Switched it to the `2021` namespace and ordered `UpdateSettings` before `UpdateUris`/`RepairUris` (consistent with Steps 6&ndash;8).
- **Copy-paste "Automatic Repair" table.** The table under *Automatic Repair* documented `UpdateURI` (an update element with an update description) instead of `RepairUri`. Corrected the element and its description.
- **Cross-links.** Added links to the authoritative `s4:UpdateUris`/`s4:UpdateUri`/`s4:RepairUris`/`s4:RepairUri` schema reference pages.

## Files
- `msix-src/app-installer/auto-update-and-repair--overview.md`
- `msix-src/app-installer/how-to-create-appinstaller-file.md`

Resolves AB#37966117