### PR TITLE
Clarify App Installer app vs. App Installer file in overview

### DIFF
--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -12,13 +12,13 @@ ms.custom: "RS5, seodec18"
 ## Purpose
 This section contains or links to articles about App Installer and how to use the features of App Installer.
 
-App Installer allows for Windows apps to be installed by double clicking the package. This means that users don't need to use PowerShell or other developer tools to deploy Windows apps. The App Installer can also install an app from the web, optional packages, and related sets.
+App Installer allows packaged Windows apps to be installed by double-clicking an app package (`.msix`/`.appx`) or app bundle (`.msixbundle`/`.appxbundle`). This means that users don't need to use PowerShell or other developer tools to deploy Windows apps. App Installer can also install an app from the web, optional packages, and related sets.
 
 App Installer is built into Windows 10 (version 1803 and later) and Windows 11, and is available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1).
 
 > [!NOTE]
 > Two related but distinct technologies share the "App Installer" name:
-> - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks a package or an `.appinstaller` file.
+> - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package (`.msix`/`.appx`), app bundle (`.msixbundle`/`.appxbundle`), or an `.appinstaller` file.
 > - The [App Installer file](app-installer-file-overview.md) (`.appinstaller`) is an XML file that specifies your package location and defines how the package is installed, updated, and repaired.
 
 To learn how to use the App Installer to install your app, see the topics in the table.

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -18,7 +18,7 @@ App Installer is built into Windows 10 (version 1803 and later) and Windows 11, 
 
 > [!NOTE]
 > Two related but distinct things share the "App Installer" name:
-> - App Installer (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
+> - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
 > - The App Installer file (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated. For details, see [App Installer file overview](app-installer-file-overview.md).
 
 To learn how to use the App Installer to install your app, see the topics in the table.

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -19,7 +19,7 @@ App Installer is built into Windows 10 (version 1803 and later) and Windows 11, 
 > [!NOTE]
 > Two related but distinct technologies share the "App Installer" name:
 > - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
-> - The [App Installer file](app-installer-file-overview.md) (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated.
+> - The [App Installer file](app-installer-file-overview.md) (`.appinstaller`) is an XML file that specifies your package location and defines how the package is installed, updated, and repaired.
 
 To learn how to use the App Installer to install your app, see the topics in the table.
 

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -1,7 +1,7 @@
 ---
 title: Install Windows 10 apps with App Installer
 description: This section contains or links to articles about App Installer and how to use the features of App Installer.
-ms.date: 04/15/2026
+ms.date: 07/04/2026
 ms.topic: install-set-up-deploy
 keywords: windows 10, windows 11, uwp, app installer, AppInstaller, sideload, related set, optional packages
 ms.custom: "RS5, seodec18"
@@ -15,6 +15,11 @@ This section contains or links to articles about App Installer and how to use th
 App Installer allows for Windows 10 apps to be installed by double clicking the app package. This means that users don't need to use PowerShell or other developer tools to deploy Windows 10 apps. The App Installer can also install an app from the web, optional packages, and related sets.
 
 App Installer is built into Windows 10 (version 1803 and later) and Windows 11, and is available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1).
+
+> [!NOTE]
+> Two related but distinct things share the "App Installer" name:
+> - **App Installer** (the app) is the built-in Windows application, available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1), that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
+> - The **App Installer file** (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated. For details, see [App Installer file overview](app-installer-file-overview.md).
 
 To learn how to use the App Installer to install your app, see the topics in the table.
 

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -17,7 +17,7 @@ App Installer allows for Windows apps to be installed by double clicking the app
 App Installer is built into Windows 10 (version 1803 and later) and Windows 11, and is available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1).
 
 > [!NOTE]
-> Two related but distinct things share the "App Installer" name:
+> Two related but distinct technologies share the "App Installer" name:
 > - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
 > - The App Installer file (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated. For details, see [App Installer file overview](app-installer-file-overview.md).
 

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -19,7 +19,7 @@ App Installer is built into Windows 10 (version 1803 and later) and Windows 11, 
 > [!NOTE]
 > Two related but distinct technologies share the "App Installer" name:
 > - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
-> - The App Installer file (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated. For details, see [App Installer file overview](app-installer-file-overview.md).
+> - The [App Installer file](app-installer-file-overview.md) (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated.
 
 To learn how to use the App Installer to install your app, see the topics in the table.
 

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -12,13 +12,13 @@ ms.custom: "RS5, seodec18"
 ## Purpose
 This section contains or links to articles about App Installer and how to use the features of App Installer.
 
-App Installer allows for Windows apps to be installed by double clicking the app package. This means that users don't need to use PowerShell or other developer tools to deploy Windows apps. The App Installer can also install an app from the web, optional packages, and related sets.
+App Installer allows for Windows apps to be installed by double clicking the package. This means that users don't need to use PowerShell or other developer tools to deploy Windows apps. The App Installer can also install an app from the web, optional packages, and related sets.
 
 App Installer is built into Windows 10 (version 1803 and later) and Windows 11, and is available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1).
 
 > [!NOTE]
 > Two related but distinct technologies share the "App Installer" name:
-> - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
+> - [App Installer](install-update-app-installer.md) (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks a package or an `.appinstaller` file.
 > - The [App Installer file](app-installer-file-overview.md) (`.appinstaller`) is an XML file that specifies your package location and defines how the package is installed, updated, and repaired.
 
 To learn how to use the App Installer to install your app, see the topics in the table.

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -18,8 +18,8 @@ App Installer is built into Windows 10 (version 1803 and later) and Windows 11, 
 
 > [!NOTE]
 > Two related but distinct things share the "App Installer" name:
-> - **App Installer** (the app) is the built-in Windows application, available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1), that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
-> - The **App Installer file** (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated. For details, see [App Installer file overview](app-installer-file-overview.md).
+> - App Installer (the app) is the built-in Windows application, available from the Microsoft Store, that provides the installation UI when a user double-clicks an app package or an `.appinstaller` file.
+> - The App Installer file (`.appinstaller`) is an XML file you author that points to your app package and defines how it is installed and updated. For details, see [App Installer file overview](app-installer-file-overview.md).
 
 To learn how to use the App Installer to install your app, see the topics in the table.
 

--- a/msix-src/app-installer/app-installer-root.md
+++ b/msix-src/app-installer/app-installer-root.md
@@ -1,5 +1,5 @@
 ---
-title: Install Windows 10 apps with App Installer
+title: Install Windows apps with App Installer
 description: This section contains or links to articles about App Installer and how to use the features of App Installer.
 ms.date: 07/04/2026
 ms.topic: install-set-up-deploy
@@ -7,12 +7,12 @@ keywords: windows 10, windows 11, uwp, app installer, AppInstaller, sideload, re
 ms.custom: "RS5, seodec18"
 ---
 
-# Install Windows 10 apps with App Installer
+# Install Windows apps with App Installer
 
 ## Purpose
 This section contains or links to articles about App Installer and how to use the features of App Installer.
 
-App Installer allows for Windows 10 apps to be installed by double clicking the app package. This means that users don't need to use PowerShell or other developer tools to deploy Windows 10 apps. The App Installer can also install an app from the web, optional packages, and related sets.
+App Installer allows for Windows apps to be installed by double clicking the app package. This means that users don't need to use PowerShell or other developer tools to deploy Windows apps. The App Installer can also install an app from the web, optional packages, and related sets.
 
 App Installer is built into Windows 10 (version 1803 and later) and Windows 11, and is available from the [Microsoft Store](https://apps.microsoft.com/detail/9nblggh4nns1).
 
@@ -40,10 +40,10 @@ To learn how to use the App Installer to install your app, see the topics in the
 
 ## Tutorials
 
-Follow these tutorials and learn how to host and install a Windows 10 app from various distribution platforms. These tutorials are useful for enterprises and developers that don't want or need to publish their apps to the Store, but still want to take advantage of the Windows 10 packaging and deployment platform.
+Follow these tutorials and learn how to host and install a Windows app from various distribution platforms. These tutorials are useful for enterprises and developers that don't want or need to publish their apps to the Store, but still want to take advantage of the Windows packaging and deployment platform.
 
 | Tutorial | Description |
 |----------|-------------|
-| [Install a Windows 10 app from an Azure Web App](web-install-azure.md) | Create an Azure Web App and use it to host and distribute your Windows 10 app package. |
-| [Install a Windows 10 app from an IIS server](web-install-IIS.md) | Set up an IIS server, verify that your web app can host app packages, and use App Installer effectively. |
-| [Hosting Windows 10 app packages on AWS for web install](web-install-aws.md) | Learn how to set up Amazon Simple Storage Service to host your Windows 10 app package from a web site. |
+| [Install a Windows app from an Azure Web App](web-install-azure.md) | Create an Azure Web App and use it to host and distribute your Windows app package. |
+| [Install a Windows app from an IIS server](web-install-IIS.md) | Set up an IIS server, verify that your web app can host app packages, and use App Installer effectively. |
+| [Hosting Windows app packages on AWS for web install](web-install-aws.md) | Learn how to set up Amazon Simple Storage Service to host your Windows app package from a web site. |


### PR DESCRIPTION
Resolves the "add App Installer overview docs" request by closing the one residual gap: the confusing overlap between the two "App Installer" concepts.

## What & why
The App Installer documentation section is already built out (overview/landing, file overview, UI, custom UX, install-from-web, security, schema reference), so the structural ask from the original bug is satisfied. The remaining actionable item was a reviewer comment that the docs never disambiguate **"App Installer app"** from **"App Installer file"**, which "can get confusing."

This change adds a short note to the section overview page (`app-installer-root.md`) that distinguishes:
- **App Installer** (the app) &mdash; the built-in Windows application (from the Microsoft Store) that provides the installation UI.
- The **App Installer file** (`.appinstaller`) &mdash; the XML manifest that points to your app package and defines how it is installed and updated.

## Files
- `msix-src/app-installer/app-installer-root.md`

Resolves AB#38195555