### PR TITLE
Rename confusing Step 6 table header on Create App Installer file page

### DIFF
--- a/msix-src/app-installer/how-to-create-appinstaller-file.md
+++ b/msix-src/app-installer/how-to-create-appinstaller-file.md
@@ -1,7 +1,7 @@
 ---
 title: Create an App Installer file manually
 description: This article describes how to install a related set via App Installer, including how to create a *.appinstaller file that defines your related set.
-ms.date: 04/15/2026
+ms.date: 07/04/2026
 ms.topic: how-to
 keywords: windows 10, uwp, app installer, AppInstaller, sideload, related set, optional packages
 ms.custom: "RS5, seodec18"
@@ -266,7 +266,7 @@ In the dependencies element, you can specify the required framework packages for
 
 The App Installer file can also specify update setting so that the related sets can be automatically updated when a newer App Installer file is published. **\<UpdateSettings\>** is an optional element. Within  **\<UpdateSettings\>** the OnLaunch option specifies that update checks should be made on app launch, and HoursBetweenUpdateChecks="12" specifies that an update check should be made every 12 hours. If HoursBetweenUpdateChecks is not specified, the default interval used to check for updates is 24 hours. Additional types of updates, like background updates can be found in the Update Settings [schema](/uwp/schemas/appinstallerschema/element-update-settings); Additional types of on-launch updates like updates with a prompt can be found in the OnLaunch [schema](/uwp/schemas/appinstallerschema/element-onlaunch)
 
-| Elements                  | Description                                                                                                                                                                   |
+| Setting                   | Description                                                                                                                                                                   |
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | HoursBetweenUpdateChecks  | Defines the minimal gap in Windows app update checks.                                                                                                                         |
 | UpdateBlocksActivation    | Defines the experience when an app update is checked for.                                                                                                                     |


### PR DESCRIPTION
Resolves a reported documentation confusion on the *Create an App Installer file manually* page.

## What & why
In **Step 6 (Add Update setting)**, the table column header was **"Elements"**, but the rows are a mix of XML attributes and one element:

- `HoursBetweenUpdateChecks`, `UpdateBlocksActivation`, `ShowPrompt` &mdash; attributes of `<OnLaunch>`
- `ForceUpdateFromAnyVersion` &mdash; the only true element

Labeling the column "Elements" is misleading (XML jargon that doesn't match the contents). This renames the header to **"Setting"**, which matches the section title ("Update setting" / `<UpdateSettings>`) and accurately describes every row.

Reported via GitHub issue #334.

## Files
- `msix-src/app-installer/how-to-create-appinstaller-file.md` (Step 6 table header only)

> [!NOTE]
> This edits the same file as PR #492, but a different, non-overlapping region (Step 6 vs. the overview example / Steps 7&ndash;8), so the two can merge in either order.

Resolves AB#40425473