### PR TITLE
Restructure TOC by audience (Phase 1: navigation)

### DIFF
--- a/msix-src/toc.yml
+++ b/msix-src/toc.yml
@@ -1,33 +1,22 @@
-- name: MSIX
-  items: 
+- name: Overview and concepts
+  items:
     - name: Overview
-      href: index.yml  
+      href: index.yml
     - name: What is MSIX?
       href: overview.md
     - name: MSIX containerization overview
       href: msix-containerization-overview.md
-    - name: Features and supported platforms 
+    - name: Features and supported platforms
       href: supported-platforms.md
     - name: MSIX appContainer apps
-      href: msix-container.md     
+      href: msix-container.md
     - name: Flexible virtualization
       href: desktop/flexible-virtualization.md
-    - name: MSIX package signing
-      items:
-        - name: Overview
-          href: package/signing-package-overview.md
-        - name: End-to-end signing guide
-          href: package/sign-msix-package-guide.md
-        - name: Sign an app package using SignTool
-          href: package/sign-app-package-using-signtool.md
-        - name: Sign an MSIX package with Device Guard signing
-          href: package/signing-package-device-guard-signing.md
-        - name: Known issues and troubleshooting 
-          href: package/signing-known-issues.md
-        - name: Unsigned MSIX for testing
-          href: package/unsigned-package.md
+    - name: App-V versus MSIX
+      href: comparisonofappvwithmsix.md
+      displayName: "App-V MSIX comparison "
     - name: App package formats
-      items: 
+      items:
         - name: Overview
           href: package/app-package-formats.md
         - name: App package architectures
@@ -46,42 +35,99 @@
           href: package/fx-packages.md
         - name: Asset packages
           href: package/asset-packages.md
-        - name: Resource Packages 
+        - name: Resource Packages
           href: package/resource-package.md
         - name: Modification packages
           href: modification-packages.md
-    - name: API and schema reference
-      items: 
-        - name: Package Manager API
-          href: /uwp/api/windows.management.deployment?context=/windows/msix/render
-        - name: Packaging APIs
-          href: /windows/desktop/appxpkg/interfaces?context=/windows/msix/render
-        - name: App manifest schema
-          href: /uwp/schemas/appxpackage/appx-package-manifest?context=/windows/msix/render
-        - name: App Installer file schema
-          href: /uwp/schemas/appinstallerschema/app-installer-file?context=/windows/msix/render
-    - name: MSIX resources
-      href: resources.md
-    - name: Customer journeys
+- name: Develop MSIX apps
+  items:
+    - name: Overview
+      href: desktop/source-code-overview.md
+    - name: Key concepts to know before packaging
       items:
         - name: Overview
-          href: customer-journey.md
-        - name: DB Systel
-          href: customer/db-systel.md
-        - name: ECNO
-          href: customer/ecno.md
-        - name: MID GmbH
-          href: customer/mid.md
-        - name: SAP
-          href: customer/sap.md
-        - name: Schneider Electric
-          href: customer/schneider-electric.md
-        - name: Trend Micro
-          href: customer/trend-micro.md
-    - name: MSIX partners
-      href: partners.md
+          href: desktop/before-packaging-overview.md
+        - name: Prepare to package a desktop app
+          href: desktop/desktop-to-uwp-prepare.md
+        - name: Understanding how packaged desktop apps run on Windows
+          href: desktop/desktop-to-uwp-behind-the-scenes.md
+        - name: Bundling MSIX packages
+          href: package/bundling-overview.md
+    - name: Packaging in Visual Studio
+      items:
+        - name: Overview
+          href: desktop/vs-package-overview.md
+        - name: Set up your desktop app for packaging in Visual Studio
+          href: desktop/desktop-to-uwp-packaging-dot-net.md
+        - name: Package a desktop or UWP app in Visual Studio
+          href: package/packaging-uwp-apps.md
+        - name: Sign packages with Azure Key Vault
+          href: desktop/sign-with-akv-cert.md
+        - name: Optimize binaries with native images
+          href: desktop/desktop-to-uwp-r2r.md
+        - name: App Attach from Visual Studio
+          href: desktop/app-attach-from-visualstudio.md
+          displayName: Azure Virtual Desktop, App Streaming, Visual Studio, Extension
+    - name: Package from the command line
+      items:
+        - name: Overview
+          href: package/manual-packaging-root.md
+        - name: Generating package artifacts
+          href: desktop/desktop-to-uwp-manual-conversion.md
+        - name: Create an MSIX package with the MakeAppx.exe tool
+          href: package/create-app-package-with-makeappx-tool.md
+        - name: Create a certificate for package signing
+          href: package/create-certificate-package-signing.md
+        - name: Sign an MSIX package using SignTool
+          href: package/sign-app-package-using-signtool.md
+        - name: Package creation with the packaging layout
+          href: package/packaging-layout.md
+        - name: Developing with asset packages and package folding
+          href: package/package-folding.md
+    - name: Sign your MSIX package
+      items:
+        - name: Overview
+          href: package/signing-package-overview.md
+        - name: End-to-end signing guide
+          href: package/sign-msix-package-guide.md
+        - name: Sign an app package using SignTool
+          href: package/sign-app-package-using-signtool.md
+        - name: Sign an MSIX package with Device Guard signing
+          href: package/signing-package-device-guard-signing.md
+        - name: Known issues and troubleshooting
+          href: package/signing-known-issues.md
+        - name: Unsigned MSIX for testing
+          href: package/unsigned-package.md
+    - name: MSIX and CI/CD pipelines
+      items:
+        - name: Overview
+          href: desktop/cicd-overview.md
+        - name: MSIX Packaging Extension
+          href: desktop/msix-packaging-extension.md
+        - name: Configure CI/CD pipeline with YAML file
+          href: desktop/azure-dev-ops.md
+        - name: Sign with Azure Key Vault in a CI/CD pipeline
+          href: desktop/cicd-keyvault.md
+    - name: Extend your app
+      items:
+        - name: Overview
+          href: desktop/extend-overview.md
+        - name: App extensions
+          href: /windows/uwp/launch-resume/how-to-create-an-extension?context=/windows/msix/render
+        - name: Custom properties for app extensions
+          href: desktop/custom-props-app-extensions.md
+        - name: Optional packages
+          href: package/optional-packages-with-executable-code.md
+        - name: Building an app with a modification package
+          href: package/modification-package-developers.md
+    - name: Update your app from code
+      items:
+        - name: Update Store-published apps from your code
+          href: store-developer-package-update.md
+        - name: Update non-Store published apps from your code
+          href: non-store-developer-updates.md
     - name: MSIX SDK
-      items: 
+      items:
         - name: Overview
           href: msix-sdk/sdk-overview.md
         - name: How to create an MSIX package on Linux
@@ -89,7 +135,7 @@
         - name: Use the MSIX SDK to distribute an MSIX package
           href: msix-sdk/sdk-guidance.md
         - name: Release notes
-          items: 
+          items:
             - name: MSIX SDK Release 1.4
               href: msix-sdk/release-notes/sdk-release-notes-1.4.md
             - name: MSIX SDK Release 1.5
@@ -98,20 +144,16 @@
               href: msix-sdk/release-notes/sdk-release-notes-1.6.md
             - name: MSIX SDK Release 1.7
               href: msix-sdk/release-notes/sdk-release-notes-1.7.md
-- name: Create an MSIX package from an existing installer
-  items: 
+- name: Repackage existing apps
+  items:
     - name: Overview
       href: packaging-tool/create-an-msix-overview.md
     - name: Know your installer
       href: packaging-tool/know-your-installer.md
-    - name: MSIX partners
-      items:
-        - name: Overview
-          href: partners.md
-        - name: Package a desktop app using third-party installers
-          href: desktop/desktop-to-uwp-third-party-installer.md
+    - name: Package a desktop app using third-party installers
+      href: desktop/desktop-to-uwp-third-party-installer.md
     - name: Set up your environment
-      items: 
+      items:
         - name: Prepare your environment for conversion
           href: packaging-tool/prepare-your-environment.md
         - name: MSIX packaging environment on Hyper-V Quick Create
@@ -119,14 +161,14 @@
         - name: Set up instructions for remote desktop machine conversions
           href: packaging-tool/remote-conversion-setup.md
     - name: Set up the MSIX Packaging Tool
-      items: 
+      items:
         - name: MSIX Packaging Tool overview
           href: packaging-tool/tool-overview.md
-        - name: Best practices for the MSIX Packaging Tool 
+        - name: Best practices for the MSIX Packaging Tool
           href: packaging-tool/tool-best-practices.md
         - name: Using the MSIX Packaging Tool in a disconnected environment
           href: packaging-tool/disconnected-environment.md
-        - name: Known issues and troubleshooting tips for the MSIX Packaging Tool 
+        - name: Known issues and troubleshooting tips for the MSIX Packaging Tool
           href: packaging-tool/tool-known-issues.md
         - name: Duplicate MSIX Packaging Tool settings across devices
           href: packaging-tool/duplicate-tool-settings-across-devices.md
@@ -137,7 +179,7 @@
         - name: Release notes for the MSIX Packaging Tool
           href: packaging-tool/release-notes/history.md
     - name: Use the MSIX Packaging Tool
-      items: 
+      items:
         - name: Create an MSIX package from any desktop installer
           href: packaging-tool/create-app-package.md
         - name: Conversion with the command line
@@ -152,7 +194,7 @@
         - name: Edit icons and assets using the MSIX Packaging Tool
           href: packaging-tool/edit-icons-and-assets.md
     - name: Tasks for after you create an MSIX package
-      items: 
+      items:
         - name: Package Support Framework (PSF)
           items:
             - name: Overview
@@ -187,7 +229,7 @@
         - name: Support legacy context menus
           href: packaging-tool/support-legacy-context-menus.md
     - name: MSIX Toolkit
-      items: 
+      items:
         - name: Overview
           href: toolkit/msix-toolkit-overview.md
         - name: Modify package publisher script
@@ -198,114 +240,28 @@
           href: toolkit/msix-toolkit-appinstallerfilebuilder.md
         - name: Accelerators
           href: toolkit/accelerators.md
-    - name: App-V versus MSIX
-      href: comparisonofappvwithmsix.md
-      displayName: "App-V MSIX comparison "
-- name: Build an MSIX package from source code
-  items: 
-    - name: Overview
-      href: desktop/source-code-overview.md
-    - name: Key concepts to know before packaging
-      items:
-        - name: Overview
-          href: desktop/before-packaging-overview.md
-        - name: Prepare to package a desktop app 
-          href: desktop/desktop-to-uwp-prepare.md
-        - name: Understanding how packaged desktop apps run on Windows
-          href: desktop/desktop-to-uwp-behind-the-scenes.md
-        - name: Bundling MSIX packages
-          href: package/bundling-overview.md
-    - name: Packaging in Visual Studio
-      items: 
-        - name: Overview
-          href: desktop/vs-package-overview.md
-        - name: Set up your desktop app for packaging in Visual Studio
-          href: desktop/desktop-to-uwp-packaging-dot-net.md
-        - name: Package a desktop or UWP app in Visual Studio
-          href: package/packaging-uwp-apps.md
-        - name: Sign packages with Azure Key Vault
-          href: desktop/sign-with-akv-cert.md
-        - name: Optimize binaries with native images
-          href: desktop/desktop-to-uwp-r2r.md
-        - name: App Attach from Visual Studio
-          href: desktop/app-attach-from-visualstudio.md
-          displayName: Azure Virtual Desktop, App Streaming, Visual Studio, Extension
-    - name: MSIX and CI/CD pipelines
-      items:
-        - name: Overview
-          href: desktop/cicd-overview.md
-        - name: MSIX Packaging Extension
-          href: desktop/msix-packaging-extension.md
-        - name: Configure CI/CD pipeline with YAML file
-          href: desktop/azure-dev-ops.md
-        - name: Sign with Azure Key Vault in a CI/CD pipeline
-          href: desktop/cicd-keyvault.md 
-    - name: Package from the command line
-      items:  
-        - name: Overview
-          href: package/manual-packaging-root.md
-        - name: Generating package artifacts
-          href: desktop/desktop-to-uwp-manual-conversion.md 
-        - name: Create an MSIX package with the MakeAppx.exe tool
-          href: package/create-app-package-with-makeappx-tool.md
-        - name: Create a certificate for package signing
-          href: package/create-certificate-package-signing.md
-        - name: Sign an MSIX package using SignTool
-          href: package/sign-app-package-using-signtool.md
-        - name: Package creation with the packaging layout
-          href: package/packaging-layout.md
-        - name: Developing with asset packages and package folding
-          href: package/package-folding.md
-    - name: Extend your app
-      items:
-        - name: Overview
-          href: desktop/extend-overview.md
-        - name: App extensions
-          href: /windows/uwp/launch-resume/how-to-create-an-extension?context=/windows/msix/render
-        - name: Custom properties for app extensions
-          href: desktop/custom-props-app-extensions.md
-        - name: Optional packages
-          href: package/optional-packages-with-executable-code.md 
-        - name: Building an app with a modification package 
-          href: package/modification-package-developers.md
-- name: Manage your MSIX deployment
-  items: 
+- name: Deploy and manage MSIX
+  items:
     - name: Overview
       href: desktop/managing-your-msix-deployment-overview.md
     - name: Plan for your deployment
       href: desktop/managing-your-msix-deployment-targetdevices.md
-    - name: Install MSIX with App Installer
-      href: app-installer/app-installer-root.md
-    - name: App installer user interface
-      href: app-installer/app-installer-ui-dialog.md
-    - name: Create custom App Installer UX
-      href: app-installer/How-to-create-custom-app-installer-ux.md
-    - name: Auto-update and repair apps
-      href: app-installer/auto-update-and-repair--overview.md
-    - name: App Installer Authentication Manager
-      href: app-installer/app-installer-authentication-manager--overview.md
-    - name: Install and update the App Installer
-      href: app-installer/install-update-app-installer.md
-    - name: App installer security Features
-      href: app-installer/app-installer-security-features.md
-    - name: Distribute your MSIX in an enterprise environment
-      items: 
-        - name: Overview
-          href: desktop/managing-your-msix-deployment-enterprise.md
-        - name: Microsoft Intune admin center
-          href: desktop/managing-your-msix-deployment-mem-adminconsole.md
-        - name: Microsoft Configuration Manager
-          href: desktop/managing-your-msix-deployment-configmgr.md
-        - name: Microsoft Intune
-          href: desktop/managing-your-msix-deployment-intune.md
-        - name: MSIX PowerShell Cmdlets
-          href: desktop/powershell-msix-cmdlets.md
-        - name: Using Group Policy
-          href: group-policy-msix.md
-        - name: Preinstalling packaged apps
-          href: desktop/deploy-preinstalled-apps.md
-        - name: Install earlier versions of an MSIX app package
-          href: desktop/managing-your-msix-deployment-downgrading.md
+    - name: Install and use App Installer
+      items:
+        - name: Install MSIX with App Installer
+          href: app-installer/app-installer-root.md
+        - name: App installer user interface
+          href: app-installer/app-installer-ui-dialog.md
+        - name: Create custom App Installer UX
+          href: app-installer/How-to-create-custom-app-installer-ux.md
+        - name: Auto-update and repair apps
+          href: app-installer/auto-update-and-repair--overview.md
+        - name: App Installer Authentication Manager
+          href: app-installer/app-installer-authentication-manager--overview.md
+        - name: Install and update the App Installer
+          href: app-installer/install-update-app-installer.md
+        - name: App installer security Features
+          href: app-installer/app-installer-security-features.md
     - name: Deploy MSIX with App Installer file
       items:
         - name: App Installer file overview
@@ -325,9 +281,27 @@
             - name: Troubleshoot installation issues with the App Installer file
               href: app-installer/troubleshoot-appinstaller-issues.md
             - name: API issues
-              href: app-installer/app-installer-api-issues.md       
+              href: app-installer/app-installer-api-issues.md
+    - name: Distribute your MSIX in an enterprise environment
+      items:
+        - name: Overview
+          href: desktop/managing-your-msix-deployment-enterprise.md
+        - name: Microsoft Intune admin center
+          href: desktop/managing-your-msix-deployment-mem-adminconsole.md
+        - name: Microsoft Configuration Manager
+          href: desktop/managing-your-msix-deployment-configmgr.md
+        - name: Microsoft Intune
+          href: desktop/managing-your-msix-deployment-intune.md
+        - name: MSIX PowerShell Cmdlets
+          href: desktop/powershell-msix-cmdlets.md
+        - name: Using Group Policy
+          href: group-policy-msix.md
+        - name: Preinstalling packaged apps
+          href: desktop/deploy-preinstalled-apps.md
+        - name: Install earlier versions of an MSIX app package
+          href: desktop/managing-your-msix-deployment-downgrading.md
     - name: Distribute your MSIX through the Web with App Installer
-      items: 
+      items:
         - name: Overview
           href: app-installer/installing-windows10-apps-web.md
         - name: Distribute a Windows 10 app from an Azure web app
@@ -339,29 +313,25 @@
     - name: Passing installation parameters to your app via App Installer
       href: app-installer/install-parameters.md
     - name: Distribute your MSIX in a consumer environment
-      items: 
+      items:
         - name: Overview
           href: desktop/managing-your-msix-deployment-retail.md
         - name: Microsoft Store
           href: /windows/uwp/publish/?context=/windows/msix/render
-    - name: Shared package container
-      href: manage/shared-package-container.md
-    - name: Create directory based on package app directory 
-      href: manage/create-directory.md
     - name: MSIX package updates
-      items: 
+      items:
         - name: Overview
           href: app-package-updates.md
         - name: Differential updates for MSIX app packages
           href: desktop/managing-your-msix-deployment-update.md
-        - name: Update Store-published apps from your code
-          href: store-developer-package-update.md
-        - name: Update non-Store published apps from your code
-          href: non-store-developer-updates.md
+    - name: Shared package container
+      href: manage/shared-package-container.md
+    - name: Create directory based on package app directory
+      href: manage/create-directory.md
     - name: MSIX persistent identity
       href: package/persistent-identity.md
-    - name: Deploy MSIX Core for Windows 10 1703 and earlier 
-      items: 
+    - name: Deploy MSIX Core for Windows 10 1703 and earlier
+      items:
         - name: Overview
           href: msix-core/msixcore.md
         - name: Deploy MSIX Core with Microsoft Endpoint Configuration Manager
@@ -375,15 +345,25 @@
         - name: Create an MSIX package with MSIX Core from source code
           href: msix-core/msixcore-clickonce-solution.md
         - name: Troubleshooting
-          href: msix-core/msixcore-troubleshoot.md  
+          href: msix-core/msixcore-troubleshoot.md
     - name: Deployment Validation and Troubleshooting
       href: desktop/managing-your-msix-deployment-troubleshooting.md
     - name: Enforcing Package Integrity check
       href: desktop/tamper-protection.md
     - name: Reset and Repair MSIX Apps
       href: desktop/managing-your-msix-reset-and-repair.md
-- name: MSIX validation, testing, and troubleshooting
-  items: 
+- name: Reference
+  items:
+    - name: Package Manager API
+      href: /uwp/api/windows.management.deployment?context=/windows/msix/render
+    - name: Packaging APIs
+      href: /windows/desktop/appxpkg/interfaces?context=/windows/msix/render
+    - name: App manifest schema
+      href: /uwp/schemas/appxpackage/appx-package-manifest?context=/windows/msix/render
+    - name: App Installer file schema
+      href: /uwp/schemas/appinstallerschema/app-installer-file?context=/windows/msix/render
+- name: Troubleshooting and validation
+  items:
     - name: Overview
       href: desktop/validation-overview.md
     - name: MSIX troubleshooting guide
@@ -406,3 +386,25 @@
       href: desktop/desktop-to-uwp-test-windows-s.md
     - name: Known issues when packaging an MSIX
       href: desktop/desktop-to-uwp-known-issues.md
+- name: Resources
+  items:
+    - name: MSIX resources
+      href: resources.md
+    - name: MSIX partners
+      href: partners.md
+    - name: Customer journeys
+      items:
+        - name: Overview
+          href: customer-journey.md
+        - name: DB Systel
+          href: customer/db-systel.md
+        - name: ECNO
+          href: customer/ecno.md
+        - name: MID GmbH
+          href: customer/mid.md
+        - name: SAP
+          href: customer/sap.md
+        - name: Schneider Electric
+          href: customer/schneider-electric.md
+        - name: Trend Micro
+          href: customer/trend-micro.md


### PR DESCRIPTION
## Summary

Restructures `msix-src/toc.yml` into **seven audience-oriented top-level nodes** to optimize navigation for the three target audiences (Development, App repackaging, App Deployment):

1. **Overview and concepts** &mdash; what MSIX is, containerization, supported platforms, appContainer, flexible virtualization, App-V vs MSIX, package formats
2. **Develop MSIX apps** *(Development)* &mdash; from-source, VS packaging, command line, signing, CI/CD, extend, update from code, MSIX SDK
3. **Repackage existing apps** *(App repackaging)* &mdash; Packaging Tool setup/use, PSF, post-package tasks, MSIX Toolkit
4. **Deploy and manage MSIX** *(App Deployment)* &mdash; deployment planning, App Installer, enterprise/web/consumer distribution, updates, shared package container, MSIX Core
5. **Reference** &mdash; APIs and schemas
6. **Troubleshooting and validation**
7. **Resources** &mdash; MSIX resources, partners, customer journeys

## Scope &amp; safety

- **Navigation-only change.** No article files are moved or renamed; **no published URLs change**; no redirects required.
- **Every article href is preserved** &mdash; verified programmatically that all **167 distinct hrefs** from the previous TOC remain reachable (0 dropped, 0 added). `displayName` search hints and external `?context=/windows/msix/render` links are retained.
- This is **Phase 1** of the docs restructure. Content right-sizing (splitting long articles into 3&ndash;4 minute reads and adding how-to + sample coverage per feature) will follow in separate, bounded PRs.